### PR TITLE
V1 - Added "rudimentary threat analysis"

### DIFF
--- a/4.0/en/0x10-V1-Architecture.md
+++ b/4.0/en/0x10-V1-Architecture.md
@@ -15,13 +15,14 @@ The category “V1” lists requirements pertaining to architecture and design o
 | **1.3** | A high-level architecture for the application and all connected remote services has been defined and security has been addressed in that architecture. |  | ✓ | ✓ | 1.0 |
 | **1.4** | Data considered sensitive in the context of the application is clearly identified. |  |  | ✓ | 1.0 |
 | **1.5** | All app components are defined in terms of the business functions and/or security functions they provide. | | | ✓ | 1.0 |
-| **1.6** | A threat model for the application and the associated remote services has been produced that identifies potential threats and countermeasures. |  |  | ✓ | 1.0 |
-| **1.7** | All security controls have a centralized implementation as to avoid duplication of critical code. | | ✓ | ✓ | 3.0 |
-| **1.8** | Components are segregated from each other via a defined security control, such as network segmentation, firewall rules, or cloud based security groups. | | ✓ | ✓ | 3.0 |
-| **1.9** | A mechanism for enforcing updates of the application exists. | | ✓ | ✓ | 3.0 |
-| **1.10** | Security is addressed within all parts of the software development lifecycle. | | ✓ | ✓ | 3.0 |
-| **1.11** | All application components, libraries, modules, frameworks, platform, and operating systems are free from known vulnerabilities. | |✓ |✓ | 3.0.1 |
-| **1.12** | There is an explicit policy for how cryptographic keys (if any) are managed, and the lifecycle of cryptographic keys is enforced. Ideally, follow a key management standard such as NIST SP 800-57. | | ✓ | ✓ | 4.0 |
+| **1.6** | A rudimentary threat analysis has been made to determine which attackers are in scope, and which are currently not in scope (e.g. the internal network is considered safe). |  | ✓ | ✓ | 4.0 |
+| **1.7** | A detailed threat model for the application and the associated remote services has been produced that identifies potential threats and countermeasures. |  |  | ✓ | 1.0 |
+| **1.8** | All security controls have a centralized implementation as to avoid duplication of critical code. | | ✓ | ✓ | 3.0 |
+| **1.9** | Components are segregated from each other via a defined security control, such as network segmentation, firewall rules, or cloud based security groups. | | ✓ | ✓ | 3.0 |
+| **1.10** | A mechanism for enforcing updates of the application exists. | | ✓ | ✓ | 3.0 |
+| **1.11** | Security is addressed within all parts of the software development lifecycle. | | ✓ | ✓ | 3.0 |
+| **1.12** | All application components, libraries, modules, frameworks, platform, and operating systems are free from known vulnerabilities. | |✓ |✓ | 3.0.1 |
+| **1.13** | There is an explicit policy for how cryptographic keys (if any) are managed, and the lifecycle of cryptographic keys is enforced. Ideally, follow a key management standard such as NIST SP 800-57. | | ✓ | ✓ | 4.0 |
 
 ## References
 

--- a/4.0/en/0x10-V1-Architecture.md
+++ b/4.0/en/0x10-V1-Architecture.md
@@ -16,7 +16,7 @@ The category “V1” lists requirements pertaining to architecture and design o
 | **1.4** | Data considered sensitive in the context of the application is clearly identified. |  |  | ✓ | 1.0 |
 | **1.5** | All app components are defined in terms of the business functions and/or security functions they provide. | | | ✓ | 1.0 |
 | **1.6** | A threat model for the application and the associated remote services has been produced that identifies potential threats and countermeasures. |  |  | ✓ | 1.0 |
-| **1.7** | All security controls have a centralized implementation. | | ✓ | ✓ | 3.0 |
+| **1.7** | All security controls have a centralized implementation as to avoid duplication of critical code. | | ✓ | ✓ | 3.0 |
 | **1.8** | Components are segregated from each other via a defined security control, such as network segmentation, firewall rules, or cloud based security groups. | | ✓ | ✓ | 3.0 |
 | **1.9** | A mechanism for enforcing updates of the application exists. | | ✓ | ✓ | 3.0 |
 | **1.10** | Security is addressed within all parts of the software development lifecycle. | | ✓ | ✓ | 3.0 |
@@ -31,7 +31,7 @@ For more information, please see:
 * [OWASP Threat Modeling Cheat Sheet](https://www.owasp.org/index.php/Application_Security_Architecture_Cheat_Sheet)
 * [OWASP Attack Surface Analysis Cheat Sheet](https://www.owasp.org/index.php/Attack_Surface_Analysis_Cheat_Sheet)
 * [OWASP Security Architecture Cheat Sheet](https://www.owasp.org/index.php/Application_Security_Architecture_Cheat_Sheet)
-* [OWASP Thread modelling](https://www.owasp.org/index.php/Application_Threat_Modeling)
+* [OWASP Threat modelling](https://www.owasp.org/index.php/Application_Threat_Modeling)
 * [OWASP Secure SDLC Cheat Sheet](https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet)
 * [Microsoft SDL](https://www.microsoft.com/en-us/sdl/)
 * [NIST SP 800-57](http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf)

--- a/4.0/en/0x11-V2-Authentication.md
+++ b/4.0/en/0x11-V2-Authentication.md
@@ -34,7 +34,7 @@ Applications can always exceed the current level's requirements. To assist in es
 | --- | --- | --- | --- | -- | -- |
 | **2.1.1** | Verify physical authenticators can be suspended or revoked, and this is effective including through Identity Providers and Relying Parties (RPs). | o | ✓ | ✓ | 5.2.1 |
 | **2.1.2** | Verify one or more of anti-automation, rate limiting, CAPTCHA, increasing delays, IP address restrictions, risk-based restrictions, is in place and effective to prevent breached credential testing, brute forcing, and account lockout attacks. Verify that no more than 100 failed attempts is possible on a single account. | o | ✓ | ✓ | 5.2.2 / 5.1.1.2|
-| **2.1.3** | Verify biometric authenticators are used as one factor of multi-factor authentication (either something you have or something you know). |  | o | ✓ | 5.2.3 |
+| **2.1.3** | Verify biometric authenticators are used as one factor of multi-factor authentication in conjunction with an other factor of either something you have and/or something you know. |  | o | ✓ | 5.2.3 |
 | **2.1.4** | Verify attestation information is available. For more information, please see NIST 800-63 B &sect; 5.2.4 |  |  | ✓ | 5.2.4 |
 | **2.1.5** | Verify impersonation resistance against phishing is in place, such as the use of client-side certificates. |  |  | ✓ | 5.2.5 |
 | **2.1.6** | Verify where a verifier and CSP are separate, mutually authenticated TLS must be in place between the verifier and the CSP. |  | o | ✓ | 5.2.6 |
@@ -43,7 +43,7 @@ Applications can always exceed the current level's requirements. To assist in es
 | **2.1.9** | Verify authentication intent by the entry of an OTP token in authentication or high value re-authentication flows, or user initiated action resulting in cryptographic device authentication, such as a button press on a FIDO hardware key. |  | o | ✓ | 5.2.9 |
 | **2.1.10** | Verify restricted authenticators - such as email and SMS - are not a preferred recovery mechanism or second factor, and at least one alternative is offered to the user first. If the user selects a restricted authenticator, a meaningful warning covering the potential risks of that restricted authenticator SHOULD be presented to the user, including that the future use of the restricted authenticator may be removed in the future. | ✓ | ✓ | ✓ | 5.2.10 |
 
-In the future, email and SMS restricted authenticators will be removed from NIST 800-63 and thus the ASVS, so they should not be the sole form of credential recovery or second factor authenticator.
+In the future, email and SMS restricted authenticators will be removed from NIST 800-63 and thus the ASVS, so they should not be the sole form of credential recovery or second factor authenticator. (Introduce concept of authenticator agility?)
 
 ### V2.2 Authenticator Lifecycle Requirements
 


### PR DESCRIPTION
Level 2 applications can benefit from a rudimentary threat model. The old 1.6 (current 1.7) addressed threat modeling for level 3, but doing nothing at all in this regard for level 2 makes little sense compared to the other requirements in the ASVS.