### PR TITLE
Update 0x18-V11 - Should this be *only* accepts HTTP headers used by app?

### DIFF
--- a/4.0/en/0x18-V11-HTTP security configuration verification requirements.md
+++ b/4.0/en/0x18-V11-HTTP security configuration verification requirements.md
@@ -11,7 +11,7 @@ Ensure that a verified application satisfies the following high level requiremen
 
 | # | Description | L1 | L2 | L3 | Since |
 | --- | --- | --- | --- | -- | -- |
-| **11.1** | Verify that the application server accepts the HTTP methods in use by the application or API, including pre-flight OPTIONS. | ✓ | ✓ | ✓ | 1.0 |
+| **11.1** | Verify that the application server only accepts the HTTP methods in use by the application or API, including pre-flight OPTIONS. | ✓ | ✓ | ✓ | 1.0 |
 | **11.2** | Verify that every HTTP response contains a content type header specifying a safe character set (e.g., UTF-8, ISO 8859-1). | ✓ | ✓ | ✓ | 1.0 |
 | **11.3** | Verify that HTTP headers added by a trusted proxy or SSO devices, such as a bearer token, are authenticated by the application. |  | ✓ | ✓ | 2.0 |
 | **11.4** | Verify that a suitable X-Frame-Options or Content-Security-Policy: frame-ancestors header is in use for sites where content should not be embedded in a 3rd party site. |  | ✓ | ✓ | 3.0.1 |


### PR DESCRIPTION
Should this be *only* accepts HTTP headers used by app or have I misunderstood?