### PR TITLE
Draft: Add redundancy to 0x24-V19-Config.md

### DIFF
--- a/4.0/en/0x24-V19-Config.md
+++ b/4.0/en/0x24-V19-Config.md
@@ -16,6 +16,7 @@ Ensure that a verified application has:
 | **19.1.2** | Verify application deployments are adequately sandboxed, containerized or isolated to delay and deter attackers from attacking other applications. | ✓ | ✓ | ✓ | 265 | [7.7](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:A/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:N) |
 | **19.1.3** | Verify that all application components, services, and servers each use their own low-privilege service account, that is not shared between applications nor used by administrators.  | ✓ | ✓ | ✓ | 250 | [7.4](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H) |
 | **19.1.4** | Verify that communications between components, such as between the application server and the database server, are encrypted, particularly when the components are in different containers or on different systems. |  | ✓ | ✓ | 319 | [4.8](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N) |
+| **19.1.5** | Verify that all mission critical components have at least one level of redundancy. |  |  | ✓ |  |  |
 
 ## 19.2 Build
 


### PR DESCRIPTION
This is a first draft for a rule that would add a redundancy requirement.
High availability is usually a requirement for critical systems as those stated in the Level 3 example for the Healthcare industry (in the old 3.0.1 documents at least). Therefore I restricted this suggested rule to only Level 3.
I'm not sure if there is any corresponding CVSSv3 or CWE reference for keeping a redundant system or failover procedure in place, so I left those out.

With regard to the actual wording I'm open for suggestions. This could either be focusing on the redundancy or the failover part or it could include both. I've just started this draft with the very simple verison of just requiring at least one level of redundancy for all mission critical components. 
Redundancy for all components is certainly nice to have, but not realistically feasible nor is it helping the seucrity of an application.

I think this is security related, because a non-available app is insecure by definition for those cases where that very high security level 3 is required.