### PR TITLE
Add newlines for project leads

### DIFF
--- a/4.0/en/0x01-Frontispiece.md
+++ b/4.0/en/0x01-Frontispiece.md
@@ -27,8 +27,8 @@ Version 4.0, 2018
 
 ## Project Leads
 
-Andrew van der Stock
-Daniel Cuthbert
+Andrew van der Stock  
+Daniel Cuthbert  
 Jim Manico
 
 ## Contributors and Reviewers


### PR DESCRIPTION
Apparently the Project Leads were meant to appear on one line each, but someone forgot that markdown transforms single line-breaks to spaces unless preceded by 2 spaces themselves.