### PR TITLE
Updated 20.7

### DIFF
--- a/4.0/en/0x25-V20-IoT.md
+++ b/4.0/en/0x25-V20-IoT.md
@@ -20,7 +20,7 @@ Embedded/IoT devices should:
 | **20.4** | Verify that on-chip debugging interfaces such as JTAG or SWD are disabled or that available protection mechanism is enabled and configured appropriately. | ✓ | ✓ | ✓ | 4.0 |
 | **20.5** | Verify that physical debug headers are not present on the device. | ✓ | ✓ | ✓ | 4.0 |
 | **20.6** | Verify that sensitive data is not stored unencrypted on the device. | ✓ | ✓ | ✓ | 4.0 |
-| **20.7** | Verify that ARM based processors make use of TrustZone and TEE (Trusted Execution Environment) | ✓ | ✓ | ✓ | 4.0 |
+| **20.7** | Verify that trusted execution is implemented and enabled, if available on the device SoC or CPU. | ✓ | ✓ | ✓ | 4.0 |
 | **20.8** | Verify that private keys and certificates are stored securely in a Secure Element, TPM, TEE (Trusted Execution Environment), or protected using strong cryptography. | ✓ | ✓ | ✓ | 4.0 |
 | **20.9** | Verify that the firmware apps protect data-in-transit using transport layer security. | ✓ | ✓ | ✓ | 4.0 |
 | **20.10** | Verify that the firmware apps validate the digital signature of server connections. | ✓ | ✓ | ✓ | 4.0 |


### PR DESCRIPTION
Hello everyone,

I suggest we change the 20.7	statement of:
* Verify that ARM based processors make use of TrustZone and TEE (Trusted Execution Environment)

to:

* Verify that trusted execution is implemented and enabled, if available on the device SoC or CPU.

Reason is very simple, there are multiple TE methods available on multiple CPUs and SoCs so a general statement is better that mandates for anything that's non-ARM specific.

Sincerely,
Tonimir