### PR TITLE
Minor change to pandoc command line

### DIFF
--- a/4.0/generate_document.sh
+++ b/4.0/generate_document.sh
@@ -13,7 +13,7 @@ if ! command_exists pandoc; then
 fi
 
 generate_docx() {
-    pandoc -s -f markdown_github --reference-docx=../templates/reference.docx --columns 10000 -t docx -o "../OWASP Application Security Verification Standard 4.0-$1.docx" *.md
+    pandoc -s -f gfm --reference-doc=../templates/reference.docx --columns 10000 -t docx -o "../OWASP Application Security Verification Standard 4.0-$1.docx" *.md
 }
 
 # generate_html() {


### PR DESCRIPTION
A couple of changes to the pandoc command line.

- `markdown_github` This has been deprecated
- `reference-docx` This has been replaced with `reference-doc`