### PR TITLE
Updates to address issue #142 and #284 - READY FOR REVIEW

### DIFF
--- a/4.0/en/0x20-V15-BusLogic.md
+++ b/4.0/en/0x20-V15-BusLogic.md
@@ -18,7 +18,7 @@ Ensure that a verified application satisfies the following high level requiremen
 | **15.4** | Verify the application monitors for unusual events or activity from a business logic perspective. For example, attempts to perform actions out of order or actions which a normal user would never attempt. |  | ✓ | ✓ | 2.0 |
 | **15.5** | Verify the application has configurable alerting when automated attacks or unusual activity is detected. |  | ✓ | ✓ | 2.0 |
 | **15.6** | Verify the application has automated reactions when automated attacks or unusual activity is detected. |  |  | ✓ | 2.0 |
-| **15.7** | Verify the application has sufficient anti-automation controls to detect and protect against data exfiltration, excessive business logic requests, or denial of service attacks. |  | ✓ | ✓ | 2.0 |
+| **15.7** | Verify the application has sufficient anti-automation controls to detect and protect against data exfiltration, excessive business logic requests, excessive file uploads or denial of service attacks. |  | ✓ | ✓ | 2.0 |
 
 ## References
 

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -22,6 +22,7 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.9** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
 | **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
 | **16.11** | Verify that the application will not accept files which are too big and could fill up the server or incur exccessive storage costs. | ✓ | ✓ | ✓ | 4.0 |
+| **16.12** | Verify that untrusted uploaded HTML files are only returned as text/plain or as direct downloads and not as text/html to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
 
 ## References
 

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -18,7 +18,7 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.5** | Verify that untrusted data is not used within cross-domain resource sharing (CORS) to protect against arbitrary remote content. See [0x92-Appendix-C_CodeExamples.md](0x92-Appendix-C_CodeExamples.md) for an example of how you might approach this. | ✓ | ✓ | ✓ | 2.0 |
 | **16.6** | Verify that files obtained from untrusted sources are stored outside the web root, with limited permissions, preferably with strong validation. |  | ✓ | ✓ | 3.0 |
 | **16.7** | Verify that the web or application server is configured by default to deny access to remote resources or systems outside the web or application server. |  | ✓ | ✓ | 2.0 |
-| **16.8** | Verify that application code does not execute uploaded data obtained from untrusted sources including both server side code but also client side code such as an HTML file with an XSS attack built in. | ✓ | ✓ | ✓ | 3.0 |
+| **16.8** | Verify that application code does not execute uploaded data obtained from untrusted sources. | ✓ | ✓ | ✓ | 3.0 |
 | **16.9** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
 | **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
 | **16.11** | Verify that the application will not files which are too big and could fill up the server or incur exccessive storage costs.]]. | ✓ | ✓ | ✓ | 4.0 |

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -14,17 +14,16 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.1** | Verify that URL redirects and forwards only allow whitelisted destinations, or show a warning when redirecting to potentially untrusted content. | ✓ | ✓ | ✓ | 2.0 |
 | **16.2** | Verify that untrusted file data submitted to the application is not used directly with file I/O commands, particularly to protect against vulnerabilities involving path traversal, local file include, file mime type, reflective file download, and OS command injection. | ✓ | ✓ | ✓ | 4.0 |
 | **16.3** | Verify that files obtained from untrusted sources are validated to be of expected type and scanned by antivirus scanners to prevent upload of known malicious content. | ✓ | ✓ | ✓ | 2.0 |
-| **16.4** | Verify that files obtained from untrusted sources are validated to be of expected type based on the file's "magic number" or other content. | | ✓ | ✓ | 4.0 |
-| **16.5** | Verify that untrusted data is not used within inclusion, class loader, or reflection capabilities to prevent remote/local code execution vulnerabilities. | ✓ | ✓ | ✓ | 4.0 |
-| **16.6** | Verify that untrusted data is not used within cross-domain resource sharing (CORS) to protect against arbitrary remote content. See [0x92-Appendix-C_CodeExamples.md](0x92-Appendix-C_CodeExamples.md) for an example of how you might approach this. | ✓ | ✓ | ✓ | 2.0 |
-| **16.7** | Verify that files obtained from untrusted sources are stored outside the web root, with limited permissions, preferably with strong validation. |  | ✓ | ✓ | 3.0 |
-| **16.8** | Verify that the web or application server is configured by default to deny access to remote resources or systems outside the web or application server. |  | ✓ | ✓ | 2.0 |
-| **16.9** | Verify that application code does not execute uploaded data obtained from untrusted sources. | ✓ | ✓ | ✓ | 3.0 |
-| **16.10** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
-| **16.11** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
-| **16.12** | Verify that the application will not accept files which are too big and could fill up the server or incur exccessive storage costs. | ✓ | ✓ | ✓ | 4.0 |
-| **16.13** | Verify that untrusted uploaded HTML and SVG files are only returned as text/plain or as direct downloads and not as text/html or that a separate sub-domain is used to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
-| **16.14** | Verify that a file size quota per user is enforced to ensure that a single user cannot fill up the server with too many files. | | ✓ | ✓ | 4.0 |
+| **16.4** | Verify that untrusted data is not used within inclusion, class loader, or reflection capabilities to prevent remote/local code execution vulnerabilities. | ✓ | ✓ | ✓ | 4.0 |
+| **16.5** | Verify that untrusted data is not used within cross-domain resource sharing (CORS) to protect against arbitrary remote content. See [0x92-Appendix-C_CodeExamples.md](0x92-Appendix-C_CodeExamples.md) for an example of how you might approach this. | ✓ | ✓ | ✓ | 2.0 |
+| **16.6** | Verify that files obtained from untrusted sources are stored outside the web root, with limited permissions, preferably with strong validation. |  | ✓ | ✓ | 3.0 |
+| **16.7** | Verify that the web or application server is configured by default to deny access to remote resources or systems outside the web or application server. |  | ✓ | ✓ | 2.0 |
+| **16.8** | Verify that application code does not execute uploaded data obtained from untrusted sources. | ✓ | ✓ | ✓ | 3.0 |
+| **16.9** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
+| **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
+| **16.11** | Verify that the application will not accept files which are too big and could fill up the server or incur exccessive storage costs. | ✓ | ✓ | ✓ | 4.0 |
+| **16.12** | Verify that untrusted uploaded HTML and SVG files are only returned as text/plain or as direct downloads and not as text/html or that a separate sub-domain is used to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
+| **16.13** | Verify that a file size quota per user is enforced to ensure that a single user cannot fill up the server with too many files. | | ✓ | ✓ | 4.0 |
 
 ## References
 

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -22,7 +22,7 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.9** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
 | **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
 | **16.11** | Verify that the application will not accept files which are too big and could fill up the server or incur exccessive storage costs. | ✓ | ✓ | ✓ | 4.0 |
-| **16.12** | Verify that untrusted uploaded HTML files are only returned as text/plain or as direct downloads and not as text/html to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
+| **16.12** | Verify that untrusted uploaded HTML files are only returned as text/plain or as direct downloads and not as text/html or that a separate sub-domain is used to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
 | **16.13** | Verify that a file size quota per user is enforced to ensure that a single user cannot fill up the server with too many files. | | ✓ | ✓ | 4.0 |
 
 ## References

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -14,16 +14,17 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.1** | Verify that URL redirects and forwards only allow whitelisted destinations, or show a warning when redirecting to potentially untrusted content. | ✓ | ✓ | ✓ | 2.0 |
 | **16.2** | Verify that untrusted file data submitted to the application is not used directly with file I/O commands, particularly to protect against vulnerabilities involving path traversal, local file include, file mime type, reflective file download, and OS command injection. | ✓ | ✓ | ✓ | 4.0 |
 | **16.3** | Verify that files obtained from untrusted sources are validated to be of expected type and scanned by antivirus scanners to prevent upload of known malicious content. | ✓ | ✓ | ✓ | 2.0 |
-| **16.4** | Verify that untrusted data is not used within inclusion, class loader, or reflection capabilities to prevent remote/local code execution vulnerabilities. | ✓ | ✓ | ✓ | 4.0 |
-| **16.5** | Verify that untrusted data is not used within cross-domain resource sharing (CORS) to protect against arbitrary remote content. See [0x92-Appendix-C_CodeExamples.md](0x92-Appendix-C_CodeExamples.md) for an example of how you might approach this. | ✓ | ✓ | ✓ | 2.0 |
-| **16.6** | Verify that files obtained from untrusted sources are stored outside the web root, with limited permissions, preferably with strong validation. |  | ✓ | ✓ | 3.0 |
-| **16.7** | Verify that the web or application server is configured by default to deny access to remote resources or systems outside the web or application server. |  | ✓ | ✓ | 2.0 |
-| **16.8** | Verify that application code does not execute uploaded data obtained from untrusted sources. | ✓ | ✓ | ✓ | 3.0 |
-| **16.9** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
-| **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
-| **16.11** | Verify that the application will not accept files which are too big and could fill up the server or incur exccessive storage costs. | ✓ | ✓ | ✓ | 4.0 |
-| **16.12** | Verify that untrusted uploaded HTML and SVG files are only returned as text/plain or as direct downloads and not as text/html or that a separate sub-domain is used to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
-| **16.13** | Verify that a file size quota per user is enforced to ensure that a single user cannot fill up the server with too many files. | | ✓ | ✓ | 4.0 |
+| **16.4** | Verify that files obtained from untrusted sources are validated to be of expected type based on the file's "magic number" or other content. | | ✓ | ✓ | 4.0 |
+| **16.5** | Verify that untrusted data is not used within inclusion, class loader, or reflection capabilities to prevent remote/local code execution vulnerabilities. | ✓ | ✓ | ✓ | 4.0 |
+| **16.6** | Verify that untrusted data is not used within cross-domain resource sharing (CORS) to protect against arbitrary remote content. See [0x92-Appendix-C_CodeExamples.md](0x92-Appendix-C_CodeExamples.md) for an example of how you might approach this. | ✓ | ✓ | ✓ | 2.0 |
+| **16.7** | Verify that files obtained from untrusted sources are stored outside the web root, with limited permissions, preferably with strong validation. |  | ✓ | ✓ | 3.0 |
+| **16.8** | Verify that the web or application server is configured by default to deny access to remote resources or systems outside the web or application server. |  | ✓ | ✓ | 2.0 |
+| **16.9** | Verify that application code does not execute uploaded data obtained from untrusted sources. | ✓ | ✓ | ✓ | 3.0 |
+| **16.10** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
+| **16.11** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
+| **16.12** | Verify that the application will not accept files which are too big and could fill up the server or incur exccessive storage costs. | ✓ | ✓ | ✓ | 4.0 |
+| **16.13** | Verify that untrusted uploaded HTML and SVG files are only returned as text/plain or as direct downloads and not as text/html or that a separate sub-domain is used to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
+| **16.14** | Verify that a file size quota per user is enforced to ensure that a single user cannot fill up the server with too many files. | | ✓ | ✓ | 4.0 |
 
 ## References
 

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -21,7 +21,7 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.8** | Verify that application code does not execute uploaded data obtained from untrusted sources. | ✓ | ✓ | ✓ | 3.0 |
 | **16.9** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
 | **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
-| **16.11** | Verify that the application will not files which are too big and could fill up the server or incur exccessive storage costs.]]. | ✓ | ✓ | ✓ | 4.0 |
+| **16.11** | Verify that the application will not accept files which are too big and could fill up the server or incur exccessive storage costs. | ✓ | ✓ | ✓ | 4.0 |
 
 ## References
 

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -24,6 +24,7 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.11** | Verify that the application will not accept files which are too big and could fill up the server or incur exccessive storage costs. | ✓ | ✓ | ✓ | 4.0 |
 | **16.12** | Verify that untrusted uploaded HTML and SVG files are only returned as text/plain or as direct downloads and not as text/html or that a separate sub-domain is used to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
 | **16.13** | Verify that a file size quota per user is enforced to ensure that a single user cannot fill up the server with too many files. | | ✓ | ✓ | 4.0 |
+| **16.14** | Verify that files obtained from untrusted sources are validated to be of expected type based on the file's "magic number" or other content. | | ✓ | ✓ | 4.0 |
 
 ## References
 

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -22,7 +22,7 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.9** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
 | **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
 | **16.11** | Verify that the application will not accept files which are too big and could fill up the server or incur exccessive storage costs. | ✓ | ✓ | ✓ | 4.0 |
-| **16.12** | Verify that untrusted uploaded HTML files are only returned as text/plain or as direct downloads and not as text/html or that a separate sub-domain is used to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
+| **16.12** | Verify that untrusted uploaded HTML and SVG files are only returned as text/plain or as direct downloads and not as text/html or that a separate sub-domain is used to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
 | **16.13** | Verify that a file size quota per user is enforced to ensure that a single user cannot fill up the server with too many files. | | ✓ | ✓ | 4.0 |
 
 ## References

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -20,7 +20,8 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.7** | Verify that the web or application server is configured by default to deny access to remote resources or systems outside the web or application server. |  | ✓ | ✓ | 2.0 |
 | **16.8** | Verify that application code does not execute uploaded data obtained from untrusted sources. | ✓ | ✓ | ✓ | 3.0 |
 | **16.9** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
-| **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | -- | -- |
+| **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
+| **16.11** | Verify that the application will not files which are too big and could fill up the server or incur exccessive storage costs.]]. | ✓ | ✓ | ✓ | 4.0 |
 
 ## References
 

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -23,6 +23,7 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
 | **16.11** | Verify that the application will not accept files which are too big and could fill up the server or incur exccessive storage costs. | ✓ | ✓ | ✓ | 4.0 |
 | **16.12** | Verify that untrusted uploaded HTML files are only returned as text/plain or as direct downloads and not as text/html to prevent the uploaded file being used to launch an XSS attack. | ✓ | ✓ | ✓ | 4.0 |
+| **16.13** | Verify that a file size quota per user is enforced to ensure that a single user cannot fill up the server with too many files. | | ✓ | ✓ | 4.0 |
 
 ## References
 

--- a/4.0/en/0x21-V16-Files-Resources.md
+++ b/4.0/en/0x21-V16-Files-Resources.md
@@ -18,7 +18,7 @@ Ensure that a verified application satisfies the following high level requiremen
 | **16.5** | Verify that untrusted data is not used within cross-domain resource sharing (CORS) to protect against arbitrary remote content. See [0x92-Appendix-C_CodeExamples.md](0x92-Appendix-C_CodeExamples.md) for an example of how you might approach this. | ✓ | ✓ | ✓ | 2.0 |
 | **16.6** | Verify that files obtained from untrusted sources are stored outside the web root, with limited permissions, preferably with strong validation. |  | ✓ | ✓ | 3.0 |
 | **16.7** | Verify that the web or application server is configured by default to deny access to remote resources or systems outside the web or application server. |  | ✓ | ✓ | 2.0 |
-| **16.8** | Verify that application code does not execute uploaded data obtained from untrusted sources. | ✓ | ✓ | ✓ | 3.0 |
+| **16.8** | Verify that application code does not execute uploaded data obtained from untrusted sources including both server side code but also client side code such as an HTML file with an XSS attack built in. | ✓ | ✓ | ✓ | 3.0 |
 | **16.9** | Verify that unsupported, insecure or deprecated client-side technologies are not used, such as NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets. | ✓ | ✓ | ✓ | 4.0 |
 | **16.10** | Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier. | ✓ | ✓ | ✓ | 4.0 |
 | **16.11** | Verify that the application will not files which are too big and could fill up the server or incur exccessive storage costs.]]. | ✓ | ✓ | ✓ | 4.0 |

--- a/4.0/en/0x24-V19-Config.md
+++ b/4.0/en/0x24-V19-Config.md
@@ -58,7 +58,7 @@ The application server contains HTTP response headers that help provide a layer 
 | **19.4.7** | Verify that a content security policy (CSPv2) is in place that helps mitigate common DOM, XSS, JSON, and JavaScript injection vulnerabilities. | ✓ | ✓ | ✓ | 3.0.1 |
 | **19.4.8** | Verify that the X-XSS-Protection: 1; mode=block header is in place to enable browser reflected XSS filters. | ✓ | ✓ | ✓ | 3.0 |
 | **19.4.9** | Verify that the supplied Origin header is not used for authentication or access control decisions, as the Origin header can easily be changed by an attacker. | ✓ | ✓ | ✓ | 4.0 |
-| **19.4.10** | Verify that the cross-domain resource sharing (CORS) Access-Control-Allow-Origin header does not reflect the request's origin header or support the "null" origin. | ✓ | ✓ | ✓ | 4.0 |
+| **19.4.10** | Verify that the cross-domain resource sharing (CORS) Access-Control-Allow-Origin header uses a strict white-list of trusted domains to match against. | ✓ | ✓ | ✓ | 4.0 |
 
 ## 19.5 Other Configuration
 


### PR DESCRIPTION
Here are responses to the points raised in #142

> I found no mention of DoS type attacks (uploading very big files or a lot of very small files). The only mention of this was in 18.4 which is specific to Web services. I think this should be added.

See: https://github.com/OWASP/ASVS/commit/88b77b5ed52bc04e6ae249771d707b9b3adf3cfb and https://github.com/OWASP/ASVS/pull/377/commits/6d3aea200d88ba818adf0d8777258775d3e1adb6

> 16.5 CORS was mentioned here but just accepting untrusted data was mentioned. I don’t think that there was anywhere in the standard where it mentioned securing CORS only to trusted domains.

See: https://github.com/OWASP/ASVS/commit/2a42ecd6b8716b70b71bab4a8547b7dd9e9e3b7d and https://github.com/OWASP/ASVS/pull/377/commits/69c4675786e2c4cf28cf992e640ac4b9aa3d3124

> 16.7 - I think this can be expanded to also allow access to certain extensions so backup files, temporary files, etc are not accessible. Or this can be added to V19

I think this is now covered by [16.10](https://github.com/OWASP/ASVS/blob/master/4.0/en/0x21-V16-Files-Resources.md#references) `Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, .bak, .swp and and similar extensions commonly used by editors should not be served by the web tier.`

> 16.8 - I think this can be expanded to cover scenarios where malicious HTML can be uploaded to then used to execute XSS attacks as in this case, the browser’s client would execute it (not the application)

See; https://github.com/OWASP/ASVS/pull/377/commits/0ed6ac26c6504a5a4182bd9cae506243d701938c

> IF this is the right section, I'd like to reference more of https://www.owasp.org/index.php/3rd_Party_Javascript_Management_Cheat_Sheet

So we now have [19.3](https://github.com/OWASP/ASVS/blob/master/4.0/en/0x24-V19-Config.md#193-dependency) which includes various 3rd party dependency topics such as Subresource Integrity and updating and [19.4.7](https://github.com/OWASP/ASVS/blob/master/4.0/en/0x24-V19-Config.md#194-http-configuration) which references Content Security Policy. Do you think that is sufficient?