### PR TITLE
Added zeroization for Level 2 too

### DIFF
--- a/4.0/en/0x93-Appendix-D_IoT.md
+++ b/4.0/en/0x93-Appendix-D_IoT.md
@@ -45,7 +45,7 @@ Embedded/IoT devices should:
 | **20.29** | Verify that sensitive traces are not exposed to outer layers of the printed circuit board. |  |  | ✓ | 4.0 |
 | **20.30** | Verify that inter-chip communication is encrypted (e.g. Main board to daughter board communication). |  |  | ✓ | 4.0 |
 | **20.31** | Verify the device uses code signing and validates code before execution. |  |  | ✓ | 4.0 |
-| **20.32** | Verify that sensitive information maintained in memory is overwritten with zeros as soon as it is no longer required. |  |  | ✓ | 4.0 |
+| **20.32** | Verify that sensitive information maintained in memory is overwritten with zeros as soon as it is no longer required. |  | ✓ | ✓ | 4.0 |
 | **20.33** | Verify that the firmware apps utilize kernel containers for isolation between apps. |  |  | ✓ | 4.0 |
 | **20.34** | Verify that secure compiler flags such as -fPIE, -fstack-protector-all, -Wl,-z,noexecstack, -Wl,-z,noexecheap are configured for firmware builds. |  |  | ✓ | 4.0 |
 | **20.35** | Verify that micro controllers are configured with code protection (if applicable). |  |  | ✓ | 4.0 |


### PR DESCRIPTION
Reason: It's simple, a standard level of security should zeroize sensitive stuff like keys etc. For level 1 i can agree that it can be omitted (but then, trusted execution is mandated on level 1 so... )