### PR TITLE
Password length proposed change

### DIFF
--- a/4.0/en/0x11-V2-Authentication.md
+++ b/4.0/en/0x11-V2-Authentication.md
@@ -80,7 +80,7 @@ Memorized secrets are not sufficient to protect against today's threats. The ASV
 
 | # | Description | L1 | L2 | L3 | NIST &sect; | CWSS |
 | :---: | :--- | :---: | :---:| :---: | :---: | :---: |
-| **2.4.1** | Verify that passwords are at least 8 characters in length. | ✓ | ✓ | ✓ | 5.1.1.2 |
+| **2.4.1** | Verify that passwords are at least 12 characters in length. | ✓ | ✓ | ✓ | 5.1.1.2 |
 | **2.4.2** | Verify that passwords 64 characters or longer are permitted. | ✓ | ✓ | ✓ | 5.1.1.2 |
 | **2.4.3** | Verify that passwords can contain spaces and truncation is not performed. Consecutive multiple spaces MAY optionally be coalesced. | ✓ | ✓ | ✓ | 5.1.1.2 |
 | **2.4.4** | Verify that Unicode characters are permitted in passwords. A single Unicode code point is considered a character, so 8 emoji or 64 kanji characters should be valid and permitted. | ✓ | ✓ | ✓ | 5.1.1.2 |


### PR DESCRIPTION
I know that 5.1.1.2 requests at least 8 characters, and i know that by proper use of password hashing (scrypt, argon etc) with salting that the issue of short passwords can be of reduced risk, but people are people. Can we at least insist on something that's not breakable trivially? Today with modern GPUs anything with 8 characters can be bruteforced in under a day (https://twitter.com/hashcat/status/1095807014079512579) can we at least bump this up 50% to 12 characters, since that would drive complexity for an average 40 character base set (lowercase,number,space!#_) to 2560000 times more complexity than 8 characters. 16 would be ideal, but let's start somewhere. 

Sincerely,
Tonimir