### PR TITLE
Correction of names in Contributors and Reviewers

### DIFF
--- a/4.0/en/0x01-Frontispiece.md
+++ b/4.0/en/0x01-Frontispiece.md
@@ -26,7 +26,7 @@ Version 4.0, 2019
 ## Contributors and Reviewers
 
 - Osama Elnaggar
-- Erland Oftedal
+- Erlend Oftedal
 - Serg Belkommen
 - David Johansson
 - Tonimir Kisasondi
@@ -50,7 +50,7 @@ Version 4.0, 2019
 - Stuart Gunter
 - Geoff Baskwill
 - Talargoni
-- Ståle Petterse
+- Ståle Pettersen
 - Kelby Ludwig
 - Jason Morrow
 - Rogan Dawes


### PR DESCRIPTION
Small typos in two names.

Correct spelling for accounts can be checked against:
https://github.com/eoftedal/
https://github.com/kozmic