### PR TITLE
Encourage SSRF prevention via libraries

### DIFF
--- a/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md
+++ b/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md
@@ -33,7 +33,7 @@ Properly implemented input validation controls, using positive whitelisting and 
 | **5.2.3** | Verify that the application sanitizes user input before passing to mail systems to protect against SMTP or IMAP injection. | ✓ | ✓ | ✓ | 147 |
 | **5.2.4** | Verify that the application avoids the use of eval() or other dynamic code execution features. Where there is no alternative, any user input being included must be sanitized or sandboxed before being executed. | ✓ | ✓ | ✓ | 95 |
 | **5.2.5** | Verify that the application protects against template injection attacks by ensuring that any user input being included is sanitized or sandboxed. | ✓ | ✓ | ✓ | 94 |
-| **5.2.6** | Verify that the application protects against SSRF attacks, by validating or sanitizing untrusted data or HTTP file metadata, such as filenames and URL input fields, use whitelisting of protocols, domains, paths and ports. | ✓ | ✓ | ✓ | 918 |
+| **5.2.6** | Verify that the application protects against SSRF attacks, by using a library designed for requesting untrusted URIs with SSRF protections built in. | ✓ | ✓ | ✓ | 918 |
 | **5.2.7** | Verify that the application sanitizes, disables, or sandboxes user-supplied Scalable Vector Graphics (SVG) scriptable content, especially as they relate to XSS resulting from inline scripts, and foreignObject. | ✓ | ✓ | ✓ | 159 |
 | **5.2.8** | Verify that the application sanitizes, disables, or sandboxes user-supplied scriptable or expression template language content, such as Markdown, CSS or XSL stylesheets, BBCode, or similar. | ✓ | ✓ | ✓ | 94 |
 


### PR DESCRIPTION
SSRF is pretty hard to protect against by only validating inputs. For example, as currently phrased in the document, redirects might break the defense. Its much better to use SSRF safe libraries designed for protecting against SSRF than try to validate.