### PR TITLE
Formalize reference standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ The requirements were developed with the following objectives in mind:
 ### How To Reference ASVS Requirements
 
 Each requirement has an identifier in the format `<chapter>.<segment>.<requirement>` where each element is a number, ex: `1.11.3`. 
-- The `<chapter>` value corresponds to a particular category of requirement, ex: all `1.#.#` requirements are `Architecture` related.
-- The `<segment>` value corresponds to a particular sub-category of requirement, ex: all `1.11.#` requirement are `Business Logic Architectural Requirements` related.
-- The `<requirement>` value identifies a specific requirement within the chapter and segment, ex: `1.11.3` which as of version 4.0.1 of this standard is:
+- The `<chapter>` value corresponds to the chapter from which the requirement comes, ex: all `1.#.#` requirements are from the `Architecture` chapter.
+- The `<segment>` value corresponds to the segment within that chapter where the requirement appears, ex: all `1.11.#` requirements are in the 'Business Logic Architectural Requirements` segment of the `Architecture` chapter.
+- The `<requirement>` value identifies the specific requirement within the chapter and segment, ex: `1.11.3` which as of version 4.0.1 of this standard is:
 
 > Verify that all high-value business logic flows, including authentication, session management and access control are thread safe and resistant to time-of-check and time-of-use race conditions.
 
-The identifiers may change between versions of the standard therefore it is preferable that other documents, reports, or tools use the format: `v<version>-<chapter>.<segment>.<requirement>`, where: 'version' is the ASVS version tag. For example: `v4.0.1-1.11.3` would be understood to mean specifically the 3rd Architecture Business Logic requirement from version 4.0.1. (This could be summarized as `v<version>-<requirement_identifier>`.)
+The identifiers may change between versions of the standard therefore it is preferable that other documents, reports, or tools use the format: `v<version>-<chapter>.<segment>.<requirement>`, where: 'version' is the ASVS version tag. For example: `v4.0.1-1.11.3` would be understood to mean specifically the 3rd requirement in the 'Business Logic Architectural Requirements' segment of the 'Architecture' chapter from version 4.0.1. (This could be summarized as `v<version>-<requirement_identifier>`.)
 
 If identifiers are used without including the `<version>` element then they should be assumed to refer to the latest Application Security Verification Standard content. Obviously as the standard grows and changes this becomes problematic, which is why writers or developers should include the version element.
 

--- a/README.md
+++ b/README.md
@@ -23,16 +23,18 @@ The requirements were developed with the following objectives in mind:
 
 ### How To Reference ASVS Requirements
 
-Each requirement has an identifier in the format `<chapter>.<segment>.<requirement>` where each element is a number, ex: `1.11.3`. 
-- The `<chapter>` value corresponds to the chapter from which the requirement comes, ex: all `1.#.#` requirements are from the `Architecture` chapter.
-- The `<segment>` value corresponds to the segment within that chapter where the requirement appears, ex: all `1.11.#` requirements are in the `Business Logic Architectural Requirements` segment of the `Architecture` chapter.
-- The `<requirement>` value identifies the specific requirement within the chapter and segment, ex: `1.11.3` which as of version 4.0.1 of this standard is:
+Each requirement has an identifier in the format `V<chapter>.<segment>.<requirement>` where each element is a number, for example: `V1.11.3`.
+- The `<chapter>` value corresponds to the chapter from which the requirement comes, for example: all `V1.#.#` requirements are from the `Architecture` chapter.
+- The `<segment>` value corresponds to the segment within that chapter where the requirement appears, for example: all `V1.11.#` requirements are in the `Business Logic Architectural Requirements` segment of the `Architecture` chapter.
+- The `<requirement>` value identifies the specific requirement within the chapter and segment, for example: `V1.11.3` which as of version 4.0.1 of this standard is:
 
 > Verify that all high-value business logic flows, including authentication, session management and access control are thread safe and resistant to time-of-check and time-of-use race conditions.
 
-The identifiers may change between versions of the standard therefore it is preferable that other documents, reports, or tools use the format: `v<version>-<chapter>.<segment>.<requirement>`, where: 'version' is the ASVS version tag. For example: `v4.0.1-1.11.3` would be understood to mean specifically the 3rd requirement in the 'Business Logic Architectural Requirements' segment of the 'Architecture' chapter from version 4.0.1. (This could be summarized as `v<version>-<requirement_identifier>`.)
+The identifiers may change between versions of the standard therefore it is preferable that other documents, reports, or tools use the format: `v<version>-V<chapter>.<segment>.<requirement>`, where: 'version' is the ASVS version tag. For example: `v4.0.1-V1.11.3` would be understood to mean specifically the 3rd requirement in the 'Business Logic Architectural Requirements' segment of the 'Architecture' chapter from version 4.0.1. (This could be summarized as `v<version>-V<requirement_identifier>`.)
 
-If identifiers are used without including the `<version>` element then they should be assumed to refer to the latest Application Security Verification Standard content. Obviously as the standard grows and changes this becomes problematic, which is why writers or developers should include the version element.
+Note: The `v` preceding the version identifier is to be lower case, while the `V` leading the identifier is a capital.
+
+If identifiers are used without including the `v<version>` element then they should be assumed to refer to the latest Application Security Verification Standard content. Obviously as the standard grows and changes this becomes problematic, which is why writers or developers should include the version element.
 
 ASVS requirement lists are made available in CSV, JSON, and other formats which may be useful for reference or programmatic use.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each requirement has an identifier in the format `V<chapter>.<segment>.<requirem
 
 The identifiers may change between versions of the standard therefore it is preferable that other documents, reports, or tools use the format: `v<version>-V<chapter>.<segment>.<requirement>`, where: 'version' is the ASVS version tag. For example: `v4.0.1-V1.11.3` would be understood to mean specifically the 3rd requirement in the 'Business Logic Architectural Requirements' segment of the 'Architecture' chapter from version 4.0.1. (This could be summarized as `v<version>-V<requirement_identifier>`.)
 
-Note: The `v` preceding the version identifier is to be lower case, while the `V` leading the identifier is a capital.
+Note: The `v` preceding the version portion is to be lower case, while the `V` leading the requirement identifier is a capital.
 
 If identifiers are used without including the `v<version>` element then they should be assumed to refer to the latest Application Security Verification Standard content. Obviously as the standard grows and changes this becomes problematic, which is why writers or developers should include the version element.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The primary aim of the OWASP Application Security Verification Standard (ASVS) P
 
 The standard provides a basis for designing, building, and testing technical application security controls, including architectural concerns, secure development lifecycle, threat modelling, agile security including continuous integration / deployment, serverless, and configuration concerns.
 
+**Please [log issues](https://github.com/OWASP/ASVS/issues) if you find any bugs or if you have ideas. We may subsequently ask you to [open a pull request](https://github.com/OWASP/ASVS/pulls) based on the discussion in the issue. We are also actively looking for translations of the 4.n branch.**
+
 ## Standard Objectives
 
 The requirements were developed with the following objectives in mind:
@@ -19,7 +21,18 @@ The requirements were developed with the following objectives in mind:
 * Assist organizations to benchmark application security tools by the percentage of coverage of the ASVS for dynamic, interactive, and static analysis tools
 * Minimize overlapping and competing requirements from other standards, by either aligning strongly with them (NIST 800-63), or being strict supersets (OWASP Top 10 2017, PCI DSS 3.2.1), which will help reduce compliance costs, effort, and time wasted in accepting unnecessary differences as risks.
 
-**Please [log issues](https://github.com/OWASP/ASVS/issues) if you find any bugs or if you have ideas. We may subsequently ask you to [open a pull request](https://github.com/OWASP/ASVS/pulls) based on the discussion in the issue. We are also actively looking for translations of the 4.n branch.**
+### How To Reference ASVS Controls
+
+Each control has an identifier in the format `<category>.<sub-category>.<control>` where each element is a number, ex: `1.11.3`. 
+- The `x` value corresponds to a particular category of control, ex: all `1.#.#` controls are `Architecture` related.
+- The `y` value corresponds to a particular sub-category of control, ex: all `1.11.#` controls are `Business Logic Architectural Requirements` related.
+- The `z` value corresponds to a specific control, ex: `1.11.3` which as of version 4.0.1 of this standard is:
+
+> Verify that all high-value business logic flows, including authentication, session management and access control are thread safe and resistant to time-of-check and time-of-use race conditions.
+
+The identifiers may change between versions of the standard therefore it is preferable that other documents, reports, or tools use the format: `v<version>-<category>.<sub-category>.<control>`, where: 'version' is the version tag with punctuation removed. For example: `v401-1.11.3` would be understood to mean specifically the 3rd Architecture Business Logic control from version 4.0.1. (This could be summarized as `v<version>-<control_identifier>`.)
+
+If identifiers are used without including the `<version>` element then they should be assumed to refer to the latest Application Security Verification Standard content. Obviously as the standard grows and changes this becomes problematic, which is why writers or developers should include the version element.
 
 ## Latest Released Version - 4.0.1
 

--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ The requirements were developed with the following objectives in mind:
 * Assist organizations to benchmark application security tools by the percentage of coverage of the ASVS for dynamic, interactive, and static analysis tools
 * Minimize overlapping and competing requirements from other standards, by either aligning strongly with them (NIST 800-63), or being strict supersets (OWASP Top 10 2017, PCI DSS 3.2.1), which will help reduce compliance costs, effort, and time wasted in accepting unnecessary differences as risks.
 
-### How To Reference ASVS Controls
+### How To Reference ASVS Requirements
 
-Each control has an identifier in the format `<category>.<sub-category>.<control>` where each element is a number, ex: `1.11.3`. 
-- The `<category>` value corresponds to a particular category of control, ex: all `1.#.#` controls are `Architecture` related.
-- The `<sub-category>` value corresponds to a particular sub-category of control, ex: all `1.11.#` controls are `Business Logic Architectural Requirements` related.
-- The `<control>` value identifies a specific control within the category and sub-category, ex: `1.11.3` which as of version 4.0.1 of this standard is:
+Each requirement has an identifier in the format `<chapter>.<segment>.<requirement>` where each element is a number, ex: `1.11.3`. 
+- The `<chapter>` value corresponds to a particular category of requirement, ex: all `1.#.#` requirements are `Architecture` related.
+- The `<segment>` value corresponds to a particular sub-category of requirement, ex: all `1.11.#` requirement are `Business Logic Architectural Requirements` related.
+- The `<requirement>` value identifies a specific requirement within the chapter and segment, ex: `1.11.3` which as of version 4.0.1 of this standard is:
 
 > Verify that all high-value business logic flows, including authentication, session management and access control are thread safe and resistant to time-of-check and time-of-use race conditions.
 
-The identifiers may change between versions of the standard therefore it is preferable that other documents, reports, or tools use the format: `v<version>-<category>.<sub-category>.<control>`, where: 'version' is the version tag with punctuation removed. For example: `v401-1.11.3` would be understood to mean specifically the 3rd Architecture Business Logic control from version 4.0.1. (This could be summarized as `v<version>-<control_identifier>`.)
+The identifiers may change between versions of the standard therefore it is preferable that other documents, reports, or tools use the format: `v<version>-<chapter>.<segment>.<requirement>`, where: 'version' is the ASVS version tag. For example: `v4.0.1-1.11.3` would be understood to mean specifically the 3rd Architecture Business Logic requirement from version 4.0.1. (This could be summarized as `v<version>-<requirement_identifier>`.)
 
 If identifiers are used without including the `<version>` element then they should be assumed to refer to the latest Application Security Verification Standard content. Obviously as the standard grows and changes this becomes problematic, which is why writers or developers should include the version element.
 
-ASVS control lists are made available in CSV, JSON, and other formats which may be useful for reference or programmatic use.
+ASVS requirement lists are made available in CSV, JSON, and other formats which may be useful for reference or programmatic use.
 
 ## Latest Released Version - 4.0.1
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ The requirements were developed with the following objectives in mind:
 ### How To Reference ASVS Controls
 
 Each control has an identifier in the format `<category>.<sub-category>.<control>` where each element is a number, ex: `1.11.3`. 
-- The `x` value corresponds to a particular category of control, ex: all `1.#.#` controls are `Architecture` related.
-- The `y` value corresponds to a particular sub-category of control, ex: all `1.11.#` controls are `Business Logic Architectural Requirements` related.
-- The `z` value corresponds to a specific control, ex: `1.11.3` which as of version 4.0.1 of this standard is:
+- The `<category>` value corresponds to a particular category of control, ex: all `1.#.#` controls are `Architecture` related.
+- The `<sub-category>` value corresponds to a particular sub-category of control, ex: all `1.11.#` controls are `Business Logic Architectural Requirements` related.
+- The `<control>` value identifies a specific control within the category and sub-category, ex: `1.11.3` which as of version 4.0.1 of this standard is:
 
 > Verify that all high-value business logic flows, including authentication, session management and access control are thread safe and resistant to time-of-check and time-of-use race conditions.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The requirements were developed with the following objectives in mind:
 
 Each requirement has an identifier in the format `<chapter>.<segment>.<requirement>` where each element is a number, ex: `1.11.3`. 
 - The `<chapter>` value corresponds to the chapter from which the requirement comes, ex: all `1.#.#` requirements are from the `Architecture` chapter.
-- The `<segment>` value corresponds to the segment within that chapter where the requirement appears, ex: all `1.11.#` requirements are in the 'Business Logic Architectural Requirements` segment of the `Architecture` chapter.
+- The `<segment>` value corresponds to the segment within that chapter where the requirement appears, ex: all `1.11.#` requirements are in the `Business Logic Architectural Requirements` segment of the `Architecture` chapter.
 - The `<requirement>` value identifies the specific requirement within the chapter and segment, ex: `1.11.3` which as of version 4.0.1 of this standard is:
 
 > Verify that all high-value business logic flows, including authentication, session management and access control are thread safe and resistant to time-of-check and time-of-use race conditions.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The identifiers may change between versions of the standard therefore it is pref
 
 If identifiers are used without including the `<version>` element then they should be assumed to refer to the latest Application Security Verification Standard content. Obviously as the standard grows and changes this becomes problematic, which is why writers or developers should include the version element.
 
+ASVS control lists are made available in CSV, JSON, and other formats which may be useful for reference or programmatic use.
+
 ## Latest Released Version - 4.0.1
 
 The latest released version is version 4.0.1 (dated 2 March 2019), which can be found:


### PR DESCRIPTION
* Added a section to README.md that details the reference standard.
  * I relocated the issues/PRs note to the intro section instead of the objective section.
* After this is accepted the text can also be added to the `www` repo.
* When 4.2 or 5 is nearing completion it could also be added to the "Using the ASVS" chapter in the verbose documents.

This Pull Request relates to issue OWASP/ASVS#715

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
