### PR TITLE
Remove triple submit cookie reference

### DIFF
--- a/4.0/en/0x21-V13-API.md
+++ b/4.0/en/0x21-V13-API.md
@@ -35,7 +35,7 @@ Once the JSON schema validation standard is formalized, ASVS will update its adv
 | **13.2.1** | Verify that enabled RESTful HTTP methods are a valid choice for the user or action, such as preventing normal users using DELETE or PUT on protected API or resources. | ✓  | ✓ | ✓ | 650 |
 | **13.2.2** | Verify that HTTP requests using the HEAD, OPTIONS, TRACE or GET verb do not modify any backend data structure or perform any state-changing actions. These requests are safe methods and should therefore not have any side effects. | ✓  | ✓ | ✓ | 650 |
 | **13.2.3** | Verify that JSON schema validation is in place and verified before accepting input. | ✓ | ✓ | ✓ | 20 |
-| **13.2.4** | Verify that RESTful web services that utilize cookies are protected from Cross-Site Request Forgery via the use of at least one or more of the following: triple or double submit cookie pattern (see [references](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)), CSRF nonces, or Origin request header checks. | ✓ | ✓ | ✓ | 352 |
+| **13.2.4** | Verify that RESTful web services that utilize cookies are protected from Cross-Site Request Forgery via the use of at least one or more of the following: double submit cookie pattern, CSRF nonces, or Origin request header checks. | ✓ | ✓ | ✓ | 352 |
 | **13.2.5** | Verify that REST services have anti-automation controls to protect against excessive calls, especially if the API is unauthenticated. |  | ✓ | ✓ | 770 |
 | **13.2.6** | Verify that REST services explicitly check the incoming Content-Type to be the expected one, such as application/xml or application/json. |  | ✓ | ✓ | 436 |
 | **13.2.7** | Verify that the message headers and payload are trustworthy and not modified in transit. Requiring strong encryption for transport (TLS only) may be sufficient in many cases as it provides both confidentiality and integrity protection. Per-message digital signatures can provide additional assurance on top of the transport protections for high-security applications but bring with them additional complexity and risks to weigh against the benefits. |  | ✓ | ✓ | 345 |
@@ -63,7 +63,7 @@ For more information, see also:
 * [OWASP Serverless Top 10](https://github.com/OWASP/Serverless-Top-10-Project/raw/master/OWASP-Top-10-Serverless-Interpretation-en.pdf)
 * [OWASP Serverless Project](https://owasp.org/www-project-serverless-top-10/)
 * [OWASP Testing Guide 4.0: Configuration and Deployment Management Testing](https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/README.html)
-* [OWASP Cross-Site Request Forgery cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#triple-submit-cookie)
+* [OWASP Cross-Site Request Forgery cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)
 * [OWASP XML External Entity Prevention Cheat Sheet - General Guidance](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#general-guidance)
 * [JSON Web Tokens (and Signing)](https://jwt.io/)
 * [REST Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html)


### PR DESCRIPTION
This Pull Request relates to issue #809 and https://github.com/OWASP/CheatSheetSeries/issues/425

Having had a quick search, my current feeling is that triple submit cookies are so rare/unknown that I don't think it is worth mentioning them for now.

@vanderaj what do you think?