### PR TITLE
Revert "Remove HTML 5 session storage as secure session token storage"

### DIFF
--- a/4.0/en/0x12-V3-Session-management.md
+++ b/4.0/en/0x12-V3-Session-management.md
@@ -25,7 +25,7 @@ As previously noted, these requirements have been adapted to be a compliant subs
 | :---: | :--- | :---: | :---:| :---: | :---: | :---: |
 | **3.2.1** | Verify the application generates a new session token on user authentication. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering)) | ✓ | ✓ | ✓ | 384 | 7.1 |
 | **3.2.2** | Verify that session tokens possess at least 64 bits of entropy. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering)) | ✓ | ✓ | ✓ | 331 | 7.1 |
-| **3.2.3** | Verify the application only stores session tokens in the browser using secure methods such as appropriately secured cookies (see section 3.4) or browser memory (i.e. Web Workers or JavaScript closures). | ✓ | ✓ | ✓ | 539 | 7.1 |
+| **3.2.3** | Verify the application only stores session tokens in the browser using secure methods such as appropriately secured cookies (see section 3.4) or HTML 5 session storage. | ✓ | ✓ | ✓ | 539 | 7.1 |
 | **3.2.4** | Verify that session token are generated using approved cryptographic algorithms. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering)) | | ✓ | ✓ | 331 | 7.1 |
 
 TLS or another secure transport channel is mandatory for session management. This is covered off in the Communications Security chapter.


### PR DESCRIPTION
Reverts OWASP/ASVS#844

Regardless of my feelings on this change, it breaks the rules for 4.0.2 because it changes what is acceptable under requirement 3.2.3. An app that previously passed this requirement because it used session storage would now fail this requirement.

[Andrew's original rules for 4.0.2](https://github.com/OWASP/ASVS/issues/750#issuecomment-625255711):
> bug fixes only. Will require some work to back port the fixes from master. The only thing I would countenance here is duplicate issue removal, spelling fixes, and clarifications.