### PR TITLE
Move 13.2.2 to 14.5.2

### DIFF
--- a/4.0/en/0x21-V13-API.md
+++ b/4.0/en/0x21-V13-API.md
@@ -33,12 +33,11 @@ Once the JSON schema validation standard is formalized, ASVS will update its adv
 | # | Description | L1 | L2 | L3 | CWE |
 | :---: | :--- | :---: | :---:| :---: | :---: |
 | **13.2.1** | Verify that enabled RESTful HTTP methods are a valid choice for the user or action, such as preventing normal users using DELETE or PUT on protected API or resources. | ✓  | ✓ | ✓ | 650 |
-| **13.2.2** | Verify that HTTP requests using the HEAD, OPTIONS, TRACE or GET verb do not modify any backend data structure or perform any state-changing actions. These requests are safe methods and should therefore not have any side effects. | ✓  | ✓ | ✓ | 650 |
-| **13.2.3** | Verify that JSON schema validation is in place and verified before accepting input. | ✓ | ✓ | ✓ | 20 |
-| **13.2.4** | Verify that RESTful web services that utilize cookies are protected from Cross-Site Request Forgery via the use of at least one or more of the following: double submit cookie pattern, CSRF nonces, or Origin request header checks. | ✓ | ✓ | ✓ | 352 |
-| **13.2.5** | Verify that REST services have anti-automation controls to protect against excessive calls, especially if the API is unauthenticated. |  | ✓ | ✓ | 770 |
-| **13.2.6** | Verify that REST services explicitly check the incoming Content-Type to be the expected one, such as application/xml or application/json. |  | ✓ | ✓ | 436 |
-| **13.2.7** | Verify that the message headers and payload are trustworthy and not modified in transit. Requiring strong encryption for transport (TLS only) may be sufficient in many cases as it provides both confidentiality and integrity protection. Per-message digital signatures can provide additional assurance on top of the transport protections for high-security applications but bring with them additional complexity and risks to weigh against the benefits. |  | ✓ | ✓ | 345 |
+| **13.2.2** | Verify that JSON schema validation is in place and verified before accepting input. | ✓ | ✓ | ✓ | 20 |
+| **13.2.3** | Verify that RESTful web services that utilize cookies are protected from Cross-Site Request Forgery via the use of at least one or more of the following: double submit cookie pattern, CSRF nonces, or Origin request header checks. | ✓ | ✓ | ✓ | 352 |
+| **13.2.4** | Verify that REST services have anti-automation controls to protect against excessive calls, especially if the API is unauthenticated. |  | ✓ | ✓ | 770 |
+| **13.2.5** | Verify that REST services explicitly check the incoming Content-Type to be the expected one, such as application/xml or application/json. |  | ✓ | ✓ | 436 |
+| **13.2.6** | Verify that the message headers and payload are trustworthy and not modified in transit. Requiring strong encryption for transport (TLS only) may be sufficient in many cases as it provides both confidentiality and integrity protection. Per-message digital signatures can provide additional assurance on top of the transport protections for high-security applications but bring with them additional complexity and risks to weigh against the benefits. |  | ✓ | ✓ | 345 |
 
 ## V13.3 SOAP Web Service Verification Requirements
 

--- a/4.0/en/0x22-V14-Config.md
+++ b/4.0/en/0x22-V14-Config.md
@@ -70,9 +70,10 @@ Configurations for production should be hardened to protect against common attac
 | # | Description | L1 | L2 | L3 | CWE |
 | --- | --- | --- | --- | -- | -- |
 | **14.5.1** | Verify that the application server only accepts the HTTP methods in use by the application/API, including pre-flight OPTIONS, and logs/alerts on any requests that are not valid for the application context. | ✓ | ✓ | ✓ | 749 |
-| **14.5.2** | Verify that the supplied Origin header is not used for authentication or access control decisions, as the Origin header can easily be changed by an attacker. | ✓ | ✓ | ✓ | 346 |
-| **14.5.3** | Verify that the Cross-Origin Resource Sharing (CORS) Access-Control-Allow-Origin header uses a strict allow list of trusted domains and subdomains to match against and does not support the "null" origin. | ✓ | ✓ | ✓ | 346 |
-| **14.5.4** | Verify that HTTP headers added by a trusted proxy or SSO devices, such as a bearer token, are authenticated by the application. | | ✓ | ✓ | 306 |
+| **14.5.2** | Verify that HTTP requests using the HEAD, OPTIONS, TRACE or GET verb do not modify any backend data structure or perform any state-changing actions. These requests are safe methods and should therefore not have any side effects. | ✓  | ✓ | ✓ | 650 |
+| **14.5.3** | Verify that the supplied Origin header is not used for authentication or access control decisions, as the Origin header can easily be changed by an attacker. | ✓ | ✓ | ✓ | 346 |
+| **14.5.4** | Verify that the Cross-Origin Resource Sharing (CORS) Access-Control-Allow-Origin header uses a strict allow list of trusted domains and subdomains to match against and does not support the "null" origin. | ✓ | ✓ | ✓ | 346 |
+| **14.5.5** | Verify that HTTP headers added by a trusted proxy or SSO devices, such as a bearer token, are authenticated by the application. | | ✓ | ✓ | 306 |
 
 ## References
 


### PR DESCRIPTION
> Verify that HTTP requests using the HEAD, OPTIONS, TRACE or GET verb do not
> modify any backend data structure or perform any state-changing actions.
> These requests are safe methods and should therefore not have any side
> effects.

I.e. don't use GET for state-changing requests.

The use of the correct HTTP method is not specific to web services, so it
should not be in V13.

Related to #672: Add check on the correct usage of safe HTTP methods
