### PR TITLE
Add request smuggling verification

### DIFF
--- a/4.0/en/0x22-V14-Config.md
+++ b/4.0/en/0x22-V14-Config.md
@@ -81,6 +81,7 @@ Configurations for production should be hardened to protect against common attac
 | **14.5.3** | [MODIFIED] Verify that the Origin header is validated against defined list of allowed domains to meet the Cross-Origin Resource Sharing (CORS) policy | ✓ | ✓ | ✓ | 346 |
 | **14.5.4** | Verify that HTTP headers added by a trusted proxy or SSO devices, such as a bearer token, are authenticated by the application. | | ✓ | ✓ | 306 |
 | **14.5.5** | [ADDED] Verify that HTTP requests using the HEAD, OPTIONS, TRACE or GET verb do not modify any backend data structure or perform any state-changing actions. These requests are safe methods and should therefore not have any side effects. | ✓ | ✓ | ✓ | 650 |
+| **14.5.6** | [ADDED] Verify that the infrastructure handles each request separately, even with conflicting Transfer-Encoding and Content-Length headers, to prevent HTTP request smuggling. | ✓ | ✓ | ✓ | 444 |
 
 ## References
 


### PR DESCRIPTION
Related to issue #889. Put in V14.5, since this vulnerability arises from a
conflict between the Transfer-Encoding and Content-Length request headers. Put
as L1 because of its possibly high impact, and it's possible to pentest it
remotely.
