### PR TITLE
Add requirement for verifying postMessage messages

### DIFF
--- a/4.0/en/0x12-V4-Access-Control.md
+++ b/4.0/en/0x12-V4-Access-Control.md
@@ -26,6 +26,7 @@ Authorization is the concept of allowing access to resources only to those permi
 | :---: | :--- | :---: | :---:| :---: | :---: |
 | **4.2.1** | Verify that sensitive data and APIs are protected against Insecure Direct Object Reference (IDOR) attacks targeting creation, reading, updating and deletion of records, such as creating or updating someone else's record, viewing everyone's records, or deleting all records. | ✓ | ✓ | ✓ | 639 |
 | **4.2.2** | Verify that the application or framework enforces a strong anti-CSRF mechanism to protect authenticated functionality, and effective anti-automation or anti-CSRF protects unauthenticated functionality. | ✓ | ✓ | ✓ | 352 |
+| **4.2.3** | [ADDED] Verify that messages received by the postMessage interface are discarded if the origin of the message is not trusted, or if the syntax of the message is invalid. | | ✓ | ✓ | 346 |
 
 ## V4.3 Other Access Control Considerations
 


### PR DESCRIPTION
Check origin and syntax. Marked this as CWE-346: Origin Validation Error.
CWE-20: Improper Input Validation would also apply.

This section, V4.2 Operation Level Access Control, is not the best fit for this
requirement, but we plan to move it to a better section later.

Related to issue #885.
