### PR TITLE
Add OpenControl Format as generated output

### DIFF
--- a/4.0/asvs.py
+++ b/4.0/asvs.py
@@ -227,6 +227,6 @@ class ASVS:
                     "name":self.asvs_opencontrol[key]["name"],
                     "description":self.asvs_opencontrol[key]["description"]
                 }
-            })
+            },sort_keys=False)
 
         return opencontrol_result

--- a/4.0/asvs.py
+++ b/4.0/asvs.py
@@ -217,8 +217,11 @@ class ASVS:
         return si.getvalue()
 
     def to_opencontrol(self):
-        ''' Returns opencontrol yaml '''
+        ''' Returns opencontrol yaml
 
+            Schema is as defined here:
+            https://github.com/opencontrol/schemas/blob/master/kwalify/standard/v1.0.0.yaml
+        '''
         opencontrol_result=yaml.dump({'name':f"{self.asvs['ShortName']}-{self.asvs['Version']}"})
         for key in self.sorted_nicely(self.asvs_opencontrol.keys()):
             opencontrol_result+=yaml.dump({

--- a/4.0/asvs.py
+++ b/4.0/asvs.py
@@ -227,6 +227,6 @@ class ASVS:
                     "name":self.asvs_opencontrol[key]["name"],
                     "description":self.asvs_opencontrol[key]["description"]
                 }
-            },sort_keys=False)
+            })
 
         return opencontrol_result

--- a/4.0/export.py
+++ b/4.0/export.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 ''' Tool for converting the ASVS requirements to various formats.
 
@@ -32,7 +32,7 @@ import argparse
 from asvs import ASVS
 
 parser = argparse.ArgumentParser(description='Export the ASVS requirements.')
-parser.add_argument('--format', choices=['json', 'json_flat', 'xml', 'csv'], default='json')
+parser.add_argument('--format', choices=['json', 'json_flat', 'xml', 'csv', 'oc'], default='json')
 parser.add_argument('--language', default='en')
 
 args = parser.parse_args()
@@ -44,6 +44,8 @@ if args.format == "csv":
 elif args.format == "xml":
     print(m.to_xml())
 elif args.format == "json_flat":
-    print(m.to_json_flat())    
+    print(m.to_json_flat())
+elif args.format == "oc":
+    print(m.to_opencontrol())
 else:
     print(m.to_json())

--- a/4.0/generate-all.sh
+++ b/4.0/generate-all.sh
@@ -1,12 +1,13 @@
-#!/bin/bash 
+#!/bin/bash
 
 lang="en"
 vers="4.0"
 verslong="./docs_$lang/OWASP Application Security Verification Standard $vers-$lang"
 
-python3 export.py --format json --language $lang > "$verslong.json"
-python3 export.py --format json_flat --language $lang > "$verslong.flat.json"
-python3 export.py --format xml --language $lang > "$verslong.xml"
-python3 export.py --format csv --language $lang > "$verslong.csv"
+python3 export.py --format json --language $lang >"$verslong.json"
+python3 export.py --format json_flat --language $lang >"$verslong.flat.json"
+python3 export.py --format xml --language $lang >"$verslong.xml"
+python3 export.py --format csv --language $lang >"$verslong.csv"
+python3 export.py --format oc --language $lang >"$verslong.opencontrol.yaml"
 
 ./generate_document.sh $lang $vers


### PR DESCRIPTION
Functional Changes
* Added support in asvs.py for generating OpenControl yaml formatted standard
* Added support in export.py for the OpenControl format flag 'oc'
* Added OpenControl format to generate-all.sh

Non-Functional Changes
* Added encoding annotation for unicode characters in regex
* Added yaml package to imports
* Added support for the bleeding-edge 4.x version string in regex
* Added natural sort helper function
* Changed export.py to use /usr/bin/env python as well

This Pull Request relates to issue #941
