### PR TITLE
Configure TLS 1.3 When Supported

### DIFF
--- a/4.0/en/0x17-V9-Communications.md
+++ b/4.0/en/0x17-V9-Communications.md
@@ -21,6 +21,7 @@ All client communications should only take place over encrypted communication pa
 | **9.1.2** | [MODIFIED] Verify using online or up to date TLS testing tools that only strong cipher suites are enabled, with the strongest cipher suites set as preferred. | ✓ | ✓ | ✓ | 326 |
 | **9.1.3** | [MODIFIED] Verify that only the latest recommended versions of the TLS protocol are enabled, such as TLS 1.2 and TLS 1.3. The latest version of the TLS protocol should be the preferred option. | ✓ | ✓ | ✓ | 326 |
 | **9.1.4** | [ADDED] For thick client applications, verify that the app either uses its own certificate store, or pins the endpoint certificate or public key, and will not establish connections with endpoints that offer a different certificate or key, even if signed by a trusted CA. | | | ✓ | 295 |
+| **9.1.5** | [ADDED, SPLIT FROM 9.1.3] Verify that only TLS 1.3 is enabled if supported by the associated web technologies, such as [Java 11](https://docs.oracle.com/en/java/javase/11/security/java-secure-socket-extension-jsse-reference-guide.html), [Python 3.7](https://docs.python.org/3/library/ssl.html#tls-1-3), [Windows Server 2022](https://docs.microsoft.com/en-us/windows/win32/secauthn/protocols-in-tls-ssl--schannel-ssp-), [Apache 2.4.38 ](https://downloads.apache.org/httpd/CHANGES_2.4) | ✓ | ✓ | ✓ | 326 |
 
 ## V9.2 Server Communications Security
 


### PR DESCRIPTION
The [Australian Cyber Security Centre
](https://www.cyber.gov.au/acsc/view-all-content/publications/implementing-certificates-tls-https-and-opportunistic-tls) states "_TLS 1.3 removed vulnerable cipher suites found in TLS 1.2, while introducing stronger cipher suites._"

This interim Pull Request is the alternative to that discussed within https://github.com/OWASP/ASVS/pull/980#issuecomment-830719090 

Signed-off-by: Christian Heinrich <christian.heinrich@cmlh.id.au>
