### PR TITLE
Specify *which* creative commons license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ If identifiers are used without including the `v<version>` element then they sho
 
 ## License
 
-The entire project content is under the **[Creative Commons v3.0](https://creativecommons.org/licenses/by-sa/3.0/)** license.
+The entire project content is under the **[Creative Commons Attribution-Share Alike v3.0](https://creativecommons.org/licenses/by-sa/3.0/)** license.


### PR DESCRIPTION
closes #1237

Be clear about **which** of the many Creative Commons licenses available in v3.0 applies to this project.

This has no impact on conformance requirements (nor licensing) beyond making it more obvious to readers what the license is.