### PR TITLE
Use ASVS repo for Package Registry

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/checkout@v3
 
       # https://github.com/marketplace/actions/push-to-ghcr
-      - name: Build and publish a Docker image for ike/documentbuilder #${{ github.repository }}
+      - name: Build and publish a Docker image for asvs/documentbuilder #${{ github.repository }}
         uses: macbre/push-to-ghcr@master
         with:
-          image_name: ike/documentbuilder #${{ github.repository }}  # it will be lowercased internally
+          image_name: asvs/documentbuilder #${{ github.repository }}  # it will be lowercased internally
           github_token: ${{ secrets.GITHUB_TOKEN }} 
           dockerfile: docker/Dockerfile
           context: docker

--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -33,7 +33,7 @@ jobs:
   build-image:
     if: needs.filters.outputs.docker == 'true'
     needs: filters
-    uses: ike/asvs/.github/workflows/build-and-publish-docker-image.yml@github-action-image
+    uses: owasp/asvs/.github/workflows/build-and-publish-docker-image.yml@master
     secrets:
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
 
@@ -42,7 +42,7 @@ jobs:
     needs: 
       - build-image
       - filters
-    uses: ike/asvs/.github/workflows/create-4.0-outputs.yml@github-action-image
+    uses: owasp/asvs/.github/workflows/create-4.0-outputs.yml@master
     secrets:
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
       GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
@@ -52,7 +52,7 @@ jobs:
     needs: 
       - build-image
       - filters
-    uses: ike/asvs/.github/workflows/create-5.0-outputs.yml@github-action-image
+    uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@master
     secrets:
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
       GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}

--- a/.github/workflows/create-5.0-outputs-debug.yml
+++ b/.github/workflows/create-5.0-outputs-debug.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare_container:
-    uses: ike/asvs/.github/workflows/create-5.0-outputs.yml@github-action-image
+    uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@master
     secrets:
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
       GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -7,13 +7,13 @@
 To build the docker image manually, use this command:
 
 ```
-docker image build --tag ghcr.io/ike/documentbuilder -f docker/Dockerfile .
+docker image build --tag ghcr.io/asvs/documentbuilder -f docker/Dockerfile .
 ```
 
 To run the document builder manually, use the following. The Volume you are mounting (`-v `) needs to be shared in the docker settings console for this to work:
 
 ```
-docker run --rm -v "/Path/to/the/repo/4.0:/data" ghcr.io/ike/documentbuilder
+docker run --rm -v "/Path/to/the/repo/4.0:/data" ghcr.io/asvs/documentbuilder
 ```
 
 ## Future Changes

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,15 @@ all: 5.0 4.0
 4.0-LANGS := $(shell cd 4.0 && git status --porcelain | sed 's/[ A-Z?]\+ \"\?4.0\///g' | sed 's/\/.*//g' | sed -n '/^\(ar\|de\|en\|es\|fr\|pt\|ru\|zh-cn\)/p' | tr '\n' ' ')
 
 5.0:
-	docker run --rm --user $(id -u):$(id -g) -v "`pwd`/5.0:/data" -v "`pwd`/docker:/scripts" -e "TARGET=5.0" -e "FORMATS=$(FORMATS)" ghcr.io/ike/documentbuilder
+	docker run --rm --user $(id -u):$(id -g) -v "`pwd`/5.0:/data" -v "`pwd`/docker:/scripts" -e "TARGET=5.0" -e "FORMATS=$(FORMATS)" ghcr.io/asvs/documentbuilder
 5.0-clean:
-	docker run --rm --user $(id -u):$(id -g) -v "`pwd`/5.0:/data" -v "`pwd`/docker:/scripts" -e "TARGET=clean" -e "FORMATS=$(FORMATS)" ghcr.io/ike/documentbuilder
+	docker run --rm --user $(id -u):$(id -g) -v "`pwd`/5.0:/data" -v "`pwd`/docker:/scripts" -e "TARGET=clean" -e "FORMATS=$(FORMATS)" ghcr.io/asvs/documentbuilder
 
 4.0:
-	docker run --rm --user $(id -u):$(id -g) -v "`pwd`/4.0:/data" -v "`pwd`/docker:/scripts" -e "TARGET=4.0" -e "FORMATS=$(FORMATS)" -e "LANGS=$(4.0-LANGS)" ghcr.io/ike/documentbuilder
+	docker run --rm --user $(id -u):$(id -g) -v "`pwd`/4.0:/data" -v "`pwd`/docker:/scripts" -e "TARGET=4.0" -e "FORMATS=$(FORMATS)" -e "LANGS=$(4.0-LANGS)" ghcr.io/asvs/documentbuilder
 4.0-clean:
-	docker run --rm --user $(id -u):$(id -g) -v "`pwd`/4.0:/data" -v "`pwd`/docker:/scripts" -e "TARGET=clean" -e "FORMATS=$(FORMATS)" ghcr.io/ike/documentbuilder
+	docker run --rm --user $(id -u):$(id -g) -v "`pwd`/4.0:/data" -v "`pwd`/docker:/scripts" -e "TARGET=clean" -e "FORMATS=$(FORMATS)" ghcr.io/asvs/documentbuilder
 
 .PHONY: 5.0 5.0-clean 4.0 4.0-clean docker
 docker:
-	docker build --build-arg CERT_FILE=docker/cert --tag ghcr.io/ike/documentbuilder:latest --network host docker
+	docker build --build-arg CERT_FILE=docker/cert --tag ghcr.io/asvs/documentbuilder:latest --network host docker


### PR DESCRIPTION
As mentioned in #1638, we need to use the package registry in the ASVS repo instead of my own fork's repo. These should be the needed code changes.