### PR TITLE
Remove automation from build documents

### DIFF
--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -1,10 +1,7 @@
 name: Build Documents
 
 on:
-  push:
-    branches:
-      - 'master'
-      - 'main'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This is not currently working and needs @ike to review. It can still be triggered manually but leaving the automation on whilst this is not working causes noise in the repository.
