### PR TITLE
chore: Update 12.3.3 CWE mapping from CWE-98 to CWE-73

### DIFF
--- a/5.0/en/0x20-V12-Files-Resources.md
+++ b/5.0/en/0x20-V12-Files-Resources.md
@@ -30,7 +30,7 @@ Although zip bombs are eminently testable using penetration testing techniques, 
 | :---: | :--- | :---: | :---: | :---: | :---: |
 | **12.3.1** | Verify that user-submitted filename metadata is not used directly by system or framework filesystems and that a URL API is used to protect against path traversal. | ✓ | ✓ | ✓ | 22 |
 | **12.3.2** | Verify that user-submitted filename metadata is validated or ignored to prevent the disclosure, creation, updating or removal of local files (LFI). | ✓ | ✓ | ✓ | 73 |
-| **12.3.3** | Verify that user-submitted filename metadata is validated or ignored to prevent the disclosure or execution of remote files via Remote File Inclusion (RFI) or Server-side Request Forgery (SSRF) attacks. | ✓ | ✓ | ✓ | 98 |
+| **12.3.3** | Verify that user-submitted filename metadata is validated or ignored to prevent the disclosure or execution of remote files via Remote File Inclusion (RFI) or Server-side Request Forgery (SSRF) attacks. | ✓ | ✓ | ✓ | 73 |
 | **12.3.4** | [MOVED TO 12.5.3] | | | | |
 | **12.3.5** | [DELETED, DUPLICATE OF 5.3.8] | | | | |
 | **12.3.6** | Verify that the application does not include and execute functionality from untrusted sources, such as unverified content distribution networks, JavaScript libraries, node npm libraries, or server-side DLLs. | | ✓ | ✓ | 829 |


### PR DESCRIPTION
Update the mapping of the ASVS requirement 12.3.3. The current mapping is to [CWE-98](https://cwe.mitre.org/data/definitions/98.html), which is specific to PHP's "Include/Require" statements. The proposed change is to map it to [CWE-73](https://cwe.mitre.org/data/definitions/73.html), which is a more generalized weakness that accurately describes the problem of allowing user-submitted input to control or influence file paths or names in filesystem operations. This more inclusive mapping covers a broader range of technologies and scenarios, making it a more suitable choice.