### PR TITLE
Github Actions for Document Building

### DIFF
--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -30,18 +30,18 @@ jobs:
   build-image:
     if: needs.filters.outputs.docker == 'true'
     needs: filters
-    uses: owasp/asvs/.github/workflows/build-and-publish-docker-image.yml@master
+    uses: owasp/asvs/.github/workflows/build-and-publish-docker-image.yml@ike-docs-automation
 
   build-v4:
     if: ${{ always() && needs.filters.outputs.v4 == 'true' }}
     needs: 
       - build-image
       - filters
-    uses: owasp/asvs/.github/workflows/create-4.0-outputs.yml@master
+    uses: owasp/asvs/.github/workflows/create-4.0-outputs.yml@ike-docs-automation
     
   build-v5:
     if: ${{ always() && needs.filters.outputs.v5 == 'true' }}
     needs: 
       - build-image
       - filters
-    uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@master
+    uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@ike-docs-automation

--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -30,18 +30,18 @@ jobs:
   build-image:
     if: needs.filters.outputs.docker == 'true'
     needs: filters
-    uses: owasp/asvs/.github/workflows/build-and-publish-docker-image.yml@ike-docs-automation
+    uses: owasp/asvs/.github/workflows/build-and-publish-docker-image.yml@master
 
   build-v4:
     if: ${{ always() && needs.filters.outputs.v4 == 'true' }}
     needs: 
       - build-image
       - filters
-    uses: owasp/asvs/.github/workflows/create-4.0-outputs.yml@ike-docs-automation
+    uses: owasp/asvs/.github/workflows/create-4.0-outputs.yml@master
     
   build-v5:
     if: ${{ always() && needs.filters.outputs.v5 == 'true' }}
     needs: 
       - build-image
       - filters
-    uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@ike-docs-automation
+    uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@master

--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: tony84727/changed-file-filter@v0.2.2
+    - uses: dorny/paths-filter@v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -31,8 +31,6 @@ jobs:
     if: needs.filters.outputs.docker == 'true'
     needs: filters
     uses: owasp/asvs/.github/workflows/build-and-publish-docker-image.yml@master
-    secrets:
-      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
 
   build-v4:
     if: ${{ always() && needs.filters.outputs.v4 == 'true' }}
@@ -40,16 +38,10 @@ jobs:
       - build-image
       - filters
     uses: owasp/asvs/.github/workflows/create-4.0-outputs.yml@master
-    secrets:
-      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
-
+    
   build-v5:
     if: ${{ always() && needs.filters.outputs.v5 == 'true' }}
     needs: 
       - build-image
       - filters
     uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@master
-    secrets:
-      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}

--- a/.github/workflows/create-4.0-outputs.yml
+++ b/.github/workflows/create-4.0-outputs.yml
@@ -4,11 +4,6 @@ name: Generate 4.0 Outputs
 on:
   # Scan on workflow call
   workflow_call:
-    secrets:
-      GHCR_USERNAME:
-        required: true
-      GHCR_TOKEN:
-        required: true
   # Scan on-demand through GitHub Actions interface:
   workflow_dispatch: {}
 
@@ -19,9 +14,9 @@ jobs:
     steps:
       - uses: docker/login-action@v2.2.0
         with: 
-          registry: ghcr.io 
-          username: ${{ secrets.GHCR_USERNAME }} 
-          password: ${{ secrets.GHCR_TOKEN }}
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
       - uses: actions/checkout@v3
       - run: make 4.0
       - uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/create-5.0-outputs-debug.yml
+++ b/.github/workflows/create-5.0-outputs-debug.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare_container:
-    uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@ike-docs-automation
+    uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@master
 
   debug:
     needs: prepare_container

--- a/.github/workflows/create-5.0-outputs-debug.yml
+++ b/.github/workflows/create-5.0-outputs-debug.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare_container:
-    uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@master
+    uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@ike-docs-automation
 
   debug:
     needs: prepare_container

--- a/.github/workflows/create-5.0-outputs-debug.yml
+++ b/.github/workflows/create-5.0-outputs-debug.yml
@@ -14,9 +14,6 @@ on:
 jobs:
   prepare_container:
     uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@master
-    secrets:
-      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
 
   debug:
     needs: prepare_container

--- a/.github/workflows/create-5.0-outputs.yml
+++ b/.github/workflows/create-5.0-outputs.yml
@@ -4,11 +4,6 @@ name: Generate 5.0 Outputs
 on:
   # Scan on workflow call
   workflow_call:
-    secrets:
-      GHCR_USERNAME:
-        required: true
-      GHCR_TOKEN:
-        required: true
   # Scan on-demand through GitHub Actions interface:
   workflow_dispatch: {}
 
@@ -19,9 +14,9 @@ jobs:
     steps:
       - uses: docker/login-action@v2.2.0
         with: 
-          registry: ghcr.io 
-          username: ${{ secrets.GHCR_USERNAME }} 
-          password: ${{ secrets.GHCR_TOKEN }}
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
       - uses: actions/checkout@v3
       - run: make 5.0
       - uses: actions/upload-artifact@v3.1.2

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -1,15 +1,18 @@
-# Note - this method is still in testing
+# Document Builder
+**Note - this method is still in testing**
 
-# How to create the document
+## Document Compilation Instructions
 1. Install Docker on your computer (see instructions for different architectures [in the Docker docs](https://docs.docker.com/engine/install/))
 2. If running WSL or WSL2 make sure that you can talk to the Docker Daemon from the console
-3. Run `make` in this directory. It will compile the latest bleeding edge to the `dist` directory of the latest release. You can specify a particular target version, i.e. `make 4.0`, or you can run `make all` to compile all versions.
+3. Build the docker image: `docker build ./docker --tag ghcr.io/owasp/asvs/documentbuilder:latest`
+4. Run `make` in this directory. It will compile the latest bleeding edge to the `dist` directory of the latest release. You can specify a 
+particular target version, i.e. `make 4.0`, or you can run `make all` to compile all versions.
 
-# Nuts and Bolts
+## Running Manually
 To build the docker image manually, use this command:
 
 ```
-docker image build --tag ghcr.io/owasp/asvs/documentbuilder -f docker/Dockerfile .
+docker build ./docker --tag ghcr.io/owasp/asvs/documentbuilder:latest
 ```
 
 To run the document builder manually, use the following. The Volume you are mounting (`-v `) needs to be shared in the docker settings console for this to work:
@@ -18,10 +21,21 @@ To run the document builder manually, use the following. The Volume you are moun
 docker run --rm -v "/Path/to/the/repo/4.0:/data" ghcr.io/owasp/asvs/documentbuilder
 ```
 
-## Future Changes
-* Hosted image to pull, so users don't have to build the docker image themselves
+To download the docker image from the repository, first create a Personal Access Token with read access to packages.
+Then you can download the docker image from the [asvs package repository](https://github.com/OWASP/ASVS/pkgs/container/asvs%2Fdocumentbuilder):
+
+```
+$ echo <TOKEN> | docker login ghcr.io -u <USERNAME> --password-stdin
+$ docker pull ghcr.io/owasp/asvs/documentbuilder:latest
+```
+
+## Background
+
+### Future Changes
+* Hosted *public* image to pull, so users don't have to build the docker image themselves or log in to ghcr.
 * Watcher to build files when source files change
 * Ability to select only certain format compilers from main Makefile
 
-## Philosophy behind this effort
-It should be easy and repeatable to create the documents. We need to provide the build environment in order to keep the effort low. This will allow for future interactions with a CI in GitLab.
+### Philosophy behind this effort
+It should be easy and repeatable to create the documents. We need to provide the build environment in order to keep the effort low. This will allow for 
+future interactions with a CI in GitLab.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,8 +19,7 @@ RUN apk add --update \
     gnupg \
     unzip \
     py3-certifi \
-    py3-setuptools \
-    py3-dicttoxml2 && \
+    py3-setuptools && \
     rm -rf /var/cache/apk/*
 
 # Dockerfiles have no "if", then we need to create intermediate stages to match a variable
@@ -60,6 +59,8 @@ RUN mkdir adobe-fonts
 RUN find $PWD/ -name "*.ttf" -exec install -m644 {} adobe-fonts/ \; || return 1
 RUN rm -rf $PWD/source*
 
+RUN pip install dicttoxml2
+
 FROM base_${WITH_CERT} as pandoc_base
 
 #install Pandoc
@@ -85,8 +86,8 @@ RUN curl --output /tmp/lua-filters.tar.gz -L https://github.com/pandoc/lua-filte
     && rm /tmp/lua-filters.tar.gz
 
 FROM pandoc_base as tinytex_base
-#Install tinyTex
 
+#Install tinyTex
 # setup path
 ENV PATH=/home/pandoc/.TinyTeX/bin/x86_64-linuxmusl/:$PATH
 ENV TINY_TEX_VERSION=v0.45

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,9 @@ RUN apk add --update \
     curl \
     gnupg \
     unzip \
-    py3-certifi && \
+    py3-certifi \
+    py3-setuptools \
+    py3-dicttoxml2 && \
     rm -rf /var/cache/apk/*
 
 # Dockerfiles have no "if", then we need to create intermediate stages to match a variable
@@ -59,10 +61,6 @@ RUN find $PWD/ -name "*.ttf" -exec install -m644 {} adobe-fonts/ \; || return 1
 RUN rm -rf $PWD/source*
 
 FROM base_${WITH_CERT} as pandoc_base
-
-#install python depencies
-RUN pip install --upgrade pip
-RUN pip install setuptools dicttoxml2
 
 #install Pandoc
 RUN adduser -s /bin/bash -g "pandoc" -D pandoc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update \
     bash \
     python3  \
     libressl-dev \
-    py3-pip \
+    pipx \
     curl \
     gnupg \
     unzip \
@@ -59,9 +59,11 @@ RUN mkdir adobe-fonts
 RUN find $PWD/ -name "*.ttf" -exec install -m644 {} adobe-fonts/ \; || return 1
 RUN rm -rf $PWD/source*
 
-RUN pip install dicttoxml2 --break-system-packages
-
 FROM base_${WITH_CERT} as pandoc_base
+
+ENV PATH /root/.py-env:$PATH
+RUN python3 -m venv /root/.py-env --system-site-packages
+RUN /root/.py-env/bin/pip install dicttoxml2
 
 #install Pandoc
 RUN adduser -s /bin/bash -g "pandoc" -D pandoc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,7 @@ RUN apk add --update \
     curl \
     gnupg \
     unzip \
-    py3-certifi \
-    py3-setuptools && \
+    py3-certifi && \
     rm -rf /var/cache/apk/*
 
 # Dockerfiles have no "if", then we need to create intermediate stages to match a variable
@@ -63,7 +62,8 @@ FROM base_${WITH_CERT} as pandoc_base
 
 ENV PATH /root/.py-env:$PATH
 RUN python3 -m venv /root/.py-env --system-site-packages
-RUN /root/.py-env/bin/pip install dicttoxml2
+RUN /root/.py-env/bin/pip install --upgrade pip 
+RUN /root/.py-env/bin/pip install dicttoxml2 setuptools==69.0.3 
 
 #install Pandoc
 RUN adduser -s /bin/bash -g "pandoc" -D pandoc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir adobe-fonts
 RUN find $PWD/ -name "*.ttf" -exec install -m644 {} adobe-fonts/ \; || return 1
 RUN rm -rf $PWD/source*
 
-RUN pip install dicttoxml2
+RUN pip install dicttoxml2 --break-system-packages
 
 FROM base_${WITH_CERT} as pandoc_base
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+. ~/.py-env/bin/activate
+
 case $TARGET in
   4.0)
     ./generate-all.sh $LANGS


### PR DESCRIPTION
This Pull Request relates to issue #1638.

This PR fixes a few things:

- Python dependency management for `dicttoxml2` as it is not packaged for Alpine
- New GHCR login using username and `GITHUB_TOKEN`, replacing the phasing-out `GHCR_TOKEN`
- Fixes filtering custom action by using a newer alternative

We now have a working builds for 5.0 and 4.x, and working Docker image build and push to [the package repo](https://github.com/OWASP/ASVS/pkgs/container/asvs%2Fdocumentbuilder). 

See built artifacts for [5.0](https://github.com/OWASP/ASVS/actions/runs/7552315665), and [4.0.3](https://github.com/OWASP/ASVS/actions/runs/7552315668).

The `Build Documents` action has been tested, but will not work as-is in this PR until it's merged into master, as it [references dependent actions](https://github.com/OWASP/ASVS/blob/ike-docs-automation/.github/workflows/build-documents.yml#L33) by the master branch version.