### PR TITLE
#1546 remove the overlapping part with 1.8.1 from 1.5.1

### DIFF
--- a/5.0/en/0x10-V1-Architecture.md
+++ b/5.0/en/0x10-V1-Architecture.md
@@ -58,7 +58,7 @@ The "untrusted client" term here refers to client-side technologies that render 
 
 | # | Description | L1 | L2 | L3 | CWE |
 | :---: | :--- | :---: | :---: | :---: | :---: |
-| **1.5.1** | Verify that input and output requirements clearly define how to handle and process data based on type, content, and applicable laws, regulations, and other policy compliance. | | ✓ | ✓ | 1029 |
+| **1.5.1** | [MODIFIED, LEVEL L2 > L1] Verify that input and output requirements clearly define how to handle and process data based on type and content. | ✓ | ✓ | ✓ | 20 |
 | **1.5.2** | [DELETED, MERGED TO 5.5.3] | | | | |
 | **1.5.3** | [MOVED TO 5.1.6] | | | | |
 | **1.5.4** | [MOVED TO 5.3.11] | | | | |


### PR DESCRIPTION

<!---
IMPORTANT NOTES:
- Changes should always be made only in the raw .md files and not in the CSV, JSON, XLSX, PDF, DOCX files, etc.
- Please do not open a pull request without first opening an associated issue.
- Please carry out all discussion in the associated issue only.
- Please refer to the following link for guidance on labeling contributions https://github.com/OWASP/ASVS/blob/master/CONTRIBUTING.md#standard-for-changes
-->

This Pull Request relates to issue #https://github.com/OWASP/ASVS/issues/1546#issuecomment-1907630050

* removed overlapping part with 1.8.1 from 1.5.1
* changed level from L2 to L1
* corrected CWE from CWE-1029 to CWE-20
