### PR TITLE
Add ReqView format as generated output

### DIFF
--- a/4.0/de/0x03-Using-ASVS.md
+++ b/4.0/de/0x03-Using-ASVS.md
@@ -15,7 +15,7 @@ Der Application Security Verification Standard definiert drei Stufen der Sicherh
 
 Jede Stufe des ASVS enthält eine Liste von Sicherheitsanforderungen. Jede dieser Anforderungen kann auch auf sicherheitsspezifische Merkmale und Fähigkeiten abgebildet werden, die von den Entwicklern in die Software eingebaut werden müssen.
 
-![ASVS Levels](https://raw.githubusercontent.com/OWASP/ASVS/master/4.0/images/asvs_40_levels_de.png "ASVS Stufen")
+![ASVS Levels](https://raw.githubusercontent.com/OWASP/ASVS/master/4.0/images/asvs_40_levels.png "ASVS Stufen")
 
 Bild 1 - Stufen des OWASP Application Security Verification Standard 4.0
 

--- a/4.0/generate-all.sh
+++ b/4.0/generate-all.sh
@@ -18,6 +18,7 @@ for lang in ${LANGS}; do
 
     python3 tools/export.py --format json --language $lang > "$verslong.json"
     python3 tools/export.py --format cdx_json --language $lang > "$verslong.cdx.json"
+    python3 tools/export.py --format reqw_json --language $lang > "$verslong.reqw"
     python3 tools/export.py --format json --language $lang --verify-only true
 
     python3 tools/export.py --format json_flat --language $lang > "$verslong.flat.json"

--- a/4.0/templates/ReqView-ASVS.reqw
+++ b/4.0/templates/ReqView-ASVS.reqw
@@ -1,0 +1,461 @@
+{
+  "documents": [
+    {
+      "id": "ASVS",
+      "name": "ASVS Security Requirements",
+      "createdOn": "2024-01-27T17:19:33.363Z",
+      "createdBy": {
+        "name": "ReqView",
+        "email": "support@reqview.com",
+        "company": "Eccam s.r.o."
+      },
+      "lastChangedOn": "2024-03-12T13:27:30.125Z",
+      "lastChangedBy": {
+        "name": "ReqView",
+        "email": "support@reqview.com",
+        "company": "Eccam s.r.o."
+      },
+      "data": [
+
+      ],
+      "attributes": {
+        "asvsId": {
+          "name": "ASVS ID",
+          "type": "string"
+        },
+        "applicable": {
+          "name": "Applicable",
+          "type": "bool"
+        },
+        "compliance": {
+          "name": "Compliance Status",
+          "type": "enum",
+          "values": [
+            {
+              "key": "NC",
+              "label": "Non-compliant"
+            },
+            {
+              "key": "PC",
+              "label": "Partially compliant"
+            },
+            {
+              "key": "FC",
+              "label": "Fully compliant"
+            }
+          ]
+        },
+        "cwe": {
+          "name": "CWE",
+          "type": "xhtml"
+        },
+        "evidence": {
+          "name": "Evidence",
+          "type": "xhtml"
+        },
+        "help": {
+          "help": true,
+          "type": "xhtml"
+        },
+        "l1": {
+          "name": "L1",
+          "type": "enum",
+          "values": [
+            {
+              "key": "NREQ",
+              "label": "Not required"
+            },
+            {
+              "key": "OPT",
+              "label": "Recommended, but not required"
+            },
+            {
+              "key": "REQ",
+              "label": "Required"
+            }
+          ]
+        },
+        "l1text": {
+          "name": "L1 Text",
+          "type": "string"
+        },
+        "l2": {
+          "name": "L2",
+          "type": "enum",
+          "values": [
+            {
+              "key": "NREQ",
+              "label": "Not required"
+            },
+            {
+              "key": "OPT",
+              "label": "Recommended, but not required"
+            },
+            {
+              "key": "REQ",
+              "label": "Required"
+            }
+          ]
+        },
+        "l2text": {
+          "name": "L2 Text",
+          "type": "string"
+        },
+        "l3": {
+          "name": "L3",
+          "type": "enum",
+          "values": [
+            {
+              "key": "NREQ",
+              "label": "Not required"
+            },
+            {
+              "key": "OPT",
+              "label": "Recommended, but not required"
+            },
+            {
+              "key": "REQ",
+              "label": "Required"
+            }
+          ]
+        },
+        "l3text": {
+          "name": "L3 Text",
+          "type": "string"
+        },
+        "nist": {
+          "name": "NIST §",
+          "type": "xhtml"
+        },
+        "ord": {
+          "name": "Ordinal",
+          "type": "int"
+        },
+        "owner": {
+          "name": "Owner",
+          "type": "string"
+        },
+        "type": {
+          "name": "Type",
+          "type": "enum",
+          "values": [
+            {
+              "key": "REQ",
+              "label": "Requirement"
+            },
+            {
+              "key": "SEC",
+              "label": "Section"
+            },
+            {
+              "key": "CHAP",
+              "label": "Chapter"
+            },
+            {
+              "key": "INFO",
+              "label": "Information"
+            }
+          ]
+        }
+      },
+      "templateColumns": {
+        "90625096-fec7-42ef-94a9-57d3e6fd5dcf": {
+          "label": "Chapter / Section",
+          "template": "{{#if (eval type \"==\" \"REQ\")}}\n  {{#withParent}}\n    {{#withParent}}\n      {{heading}}\n    {{/withParent}}\n    / {{heading}}\n  {{/withParent}}\n{{/if}}"
+        }
+      },
+      "views": {
+        "Level 1 Compliance": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "templateColumnId": "90625096-fec7-42ef-94a9-57d3e6fd5dcf",
+              "width": 180
+            },
+            {
+              "columnId": "description",
+              "width": 400
+            },
+            {
+              "columnId": "owner",
+              "width": 150
+            },
+            {
+              "columnId": "compliance",
+              "width": 150
+            },
+            {
+              "columnId": "evidence",
+              "width": 220
+            }
+          ],
+          "filter": [
+            [
+              {
+                "attributeId": "type",
+                "criterion": "attribute",
+                "value": "REQ"
+              },
+              {
+                "attributeId": "applicable",
+                "criterion": "attribute",
+                "value": "true"
+              },
+              {
+                "attributeId": "l1",
+                "criterion": "attribute",
+                "not": true,
+                "value": "NREQ"
+              }
+            ]
+          ]
+        },
+        "Level 2 Compliance": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "templateColumnId": "90625096-fec7-42ef-94a9-57d3e6fd5dcf",
+              "width": 180
+            },
+            {
+              "columnId": "description",
+              "width": 400
+            },
+            {
+              "columnId": "owner",
+              "width": 150
+            },
+            {
+              "columnId": "compliance",
+              "width": 150
+            },
+            {
+              "columnId": "evidence",
+              "width": 220
+            }
+          ],
+          "filter": [
+            [
+              {
+                "attributeId": "type",
+                "criterion": "attribute",
+                "value": "REQ"
+              },
+              {
+                "attributeId": "applicable",
+                "criterion": "attribute",
+                "value": "true"
+              },
+              {
+                "attributeId": "l2",
+                "criterion": "attribute",
+                "not": true,
+                "value": "NREQ"
+              }
+            ]
+          ]
+        },
+        "Level 3 Compliance": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "templateColumnId": "90625096-fec7-42ef-94a9-57d3e6fd5dcf",
+              "width": 180
+            },
+            {
+              "columnId": "description",
+              "width": 400
+            },
+            {
+              "columnId": "owner",
+              "width": 150
+            },
+            {
+              "columnId": "compliance",
+              "width": 150
+            },
+            {
+              "columnId": "evidence",
+              "width": 220
+            }
+          ],
+          "filter": [
+            [
+              {
+                "attributeId": "type",
+                "criterion": "attribute",
+                "value": "REQ"
+              },
+              {
+                "attributeId": "applicable",
+                "criterion": "attribute",
+                "value": "true"
+              },
+              {
+                "attributeId": "l3",
+                "criterion": "attribute",
+                "not": true,
+                "value": "NREQ"
+              }
+            ]
+          ]
+        },
+        "Manage": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "columnId": "description",
+              "width": 437
+            },
+            {
+              "columnId": "l1",
+              "width": 80
+            },
+            {
+              "columnId": "l2",
+              "width": 80
+            },
+            {
+              "columnId": "l3",
+              "width": 80
+            },
+            {
+              "columnId": "applicable",
+              "width": 90
+            },
+            {
+              "columnId": "owner",
+              "width": 150
+            },
+            {
+              "columnId": "compliance",
+              "width": 150
+            }
+          ],
+          "filter": [
+            [
+              {
+                "attributeId": "type",
+                "criterion": "attribute",
+                "not": true,
+                "value": "INFO"
+              }
+            ]
+          ]
+        },
+        "Primary": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "type",
+              "width": 110
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "columnId": "description",
+              "width": 550
+            },
+            {
+              "columnId": "l1text",
+              "width": 70
+            },
+            {
+              "columnId": "l2text",
+              "width": 70
+            },
+            {
+              "columnId": "l3text",
+              "width": 70
+            },
+            {
+              "columnId": "cwe",
+              "width": 70
+            },
+            {
+              "columnId": "nist",
+              "width": 120
+            }
+          ],
+          "default": true
+        },
+        "Traceability": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "templateColumnId": "90625096-fec7-42ef-94a9-57d3e6fd5dcf",
+              "width": 180
+            },
+            {
+              "columnId": "description",
+              "width": 450
+            },
+            {
+              "columnId": "links",
+              "width": 450
+            }
+          ],
+          "filter": [
+            [
+              {
+                "attributeId": "applicable",
+                "criterion": "attribute",
+                "value": "true"
+              }
+            ]
+          ]
+        }
+      }
+    }
+  ],
+  "attachments": {
+  },
+  "copyright": [
+    "Copyright © The OWASP Foundation"
+  ],
+  "url": "https://owasp.org/www-project-application-security-verification-standard/",
+  "metadata": {
+    "format": "2.17",
+    "template": "document"
+  }
+}

--- a/4.0/tools/asvs.py
+++ b/4.0/tools/asvs.py
@@ -30,10 +30,15 @@
 import os
 import re
 import json
+import base64
+import urllib.request
+import datetime
 from xml.sax.saxutils import escape
 import csv
 from dicttoxml2 import dicttoxml
 import xml.etree.ElementTree as ET
+from marko.ext.gfm import gfm
+
 try:
     from StringIO import StringIO
 except ImportError:
@@ -45,9 +50,9 @@ class ASVS:
     asvs['Name'] = "Application Security Verification Standard Project"
     asvs['ShortName'] = "ASVS"
     asvs['Version'] = ""
-    asvs['Description'] = "The OWASP Application Security Verification Standard (ASVS) Project " \
-        "provides a basis for testing web application technical security controls and also " \
-        "provides developers with a list of requirements for secure development."
+    asvs['Description'] = ("The OWASP Application Security Verification Standard (ASVS) Project "
+            "provides a basis for testing web application technical security controls and also "
+            "provides developers with a list of requirements for secure development.")
 
     asvs_flat = {}
     asvs_flat2 = {}
@@ -55,13 +60,15 @@ class ASVS:
     asvs_flat2['requirements'] = []
     language = ''
 
-    def __init__(self, language_in):    
-        
+    rv = json.load(open(os.path.join("templates", "ReqView-ASVS.reqw"), encoding="utf8"))
+
+    def __init__(self, language_in):
+
         self.language = language_in
         prefix_char1, prefix_char2, prefix_char1_b = self.get_prefix()
 
-        regex = re.compile('Version (([\d.]+){3})')
-        
+        regex = re.compile(r'Version (([\d.]+){3})')
+
         for line in open(os.path.join(self.language, "0x01-Frontispiece.md"), encoding="utf8"):
             m = re.search(regex, line)
             if m:
@@ -74,13 +81,89 @@ class ASVS:
             m = re.search(regex, content.read())
             if m:
                 self.asvs['Description'] = m.group(1)
+                self.rv['description'] = m.group(1)
+
+        nist_url = "https://pages.nist.gov/800-63-3/sp800-63b.html"
+        nist_html = urllib.request.urlopen(nist_url).read().decode()
+        nist_headings = ["".join(h) for h in re.findall(r'<h[34]([^>]*)>(.+)</h[34]>', nist_html)]
+        nist_map = {}
+        for h in nist_headings:
+            if secnum := re.findall(r'[1-9A]+\.[0-9\.]+', h):
+                if a_id := re.findall(r'id="(.+)"', h):
+                    nist_map[secnum[0]] = a_id[0]
+                if a_name := re.findall(r'name="(.+)"', h):
+                    nist_map[secnum[0]] = a_name[0]
 
         self.asvs['Requirements'] = chapters = []
+        rv_doc = self.rv['documents'][0]
+        timestamp = datetime.datetime.now(datetime.UTC).isoformat(timespec='milliseconds')[:-6] + "Z"
+        rv_doc['createdOn'] = rv_doc['lastChangedOn'] = timestamp
 
-    
+        rv_chapters = rv_doc['data'] = []
+        if self.language == 'ar':
+            rv_doc['rtl'] = True
+
+        self.rv['attachments'] = {}
+        rv_stack = [rv_chapters]
+
+        rv_level = 0
+
+        def rv_parse_md(file, stack, level):
+            doc = gfm.parse(open(os.path.join(self.language, file), encoding="utf8").read())
+            obj = None
+            for e in doc.children:
+                t = e.get_type()
+                if t == "Heading":
+                    if not e.children:
+                        continue
+                    h_obj = {
+                        'heading': e.children[0].children,
+                        'children': [],
+                        'type': 'INFO'
+                    }
+                    obj = None
+                    if e.level > level:
+                        level += 1
+                    else:
+                        while e.level < level:
+                            stack.pop()
+                            level -= 1
+                        if e.level == level:
+                            stack.pop()
+                    stack[-1].append(h_obj)
+                    stack.append(h_obj['children'])
+                elif t != "BlankLine":
+                    if obj is None:
+                        obj = {
+                            'text': "",
+                            'type': 'INFO'
+                        }
+                        stack[-1].append(obj)
+                    if e.children:
+                        for img in [c for c in e.children if c.get_type() == "Image"]:
+                            if img.dest.startswith("https://"):
+                                stream = urllib.request.urlopen(img.dest)
+                            else:
+                                stream = open(os.path.join(self.language, img.dest), "rb")
+                            att_id = os.path.basename(img.dest)
+                            if 'attachments' not in obj:
+                                obj['attachments'] = []
+                            obj['attachments'].append(att_id)
+                            b64_data = base64.b64encode(stream.read())
+                            self.rv['attachments'][att_id] = {'data': f"data:image/png;base64,{b64_data.decode()}"}
+
+                        e.children = [c for c in e.children if c.get_type() != "Image"]
+                    html = gfm.render(e)
+                    if html and html != "<p></p>\n":
+                        obj['text'] += self.rv_html(html)
+            return level
+
         for file in sorted(os.listdir(self.language)):
 
-            if re.match("0x\d{2}-V", file):
+            if re.match(r"0x0\d-.+\.md$", file):
+                rv_level = rv_parse_md(file, rv_stack, rv_level)
+
+            if re.match(r"0x\d{2}-V", file):
                 chapter = {}
                 chapter['Shortcode'] = ""
                 chapter['Ordinal'] = ""
@@ -88,13 +171,31 @@ class ASVS:
                 chapter['Name'] = ""
                 chapter['Items'] = []
 
+                # never used by rv
+                rv_chapter = {
+                    'type': 'CHAP',
+                    'asvsId': "",
+                    'ord': "",
+                    'heading': "",  # ShortName
+                    'children': []
+                }
+
                 section = {}
                 section['Shortcode'] = ""
                 section['Ordinal'] = ""
                 section['Name'] = ""
                 section['Items'] = []
 
-                regex = re.compile('0x\d{2}-(V([0-9]{1,3}))-(\w[^-.]*)')
+                # never used by rv
+                rv_section = {
+                    'type': 'SEC',
+                    'shortcode': "",
+                    'ord': "",
+                    'heading': "",  # Name
+                    'children': []
+                }
+
+                regex = re.compile(r'0x\d{2}-(V([0-9]{1,3}))-(\w[^-.]*)')
                 m = re.search(regex, file)
                 if m:
                     chapter = {}
@@ -104,51 +205,104 @@ class ASVS:
                     chapter['Name'] = ""
                     chapter['Items'] = []
 
+                    rv_chapter = {
+                        'type': 'CHAP',
+                        'asvsId': chapter['Shortcode'][1:],
+                        'ord': chapter['Ordinal'],
+                        'heading': chapter['ShortName'],
+                        'children': []
+                    }
+
                     section = {}
                     section['Shortcode'] = m.group(1).replace('V', prefix_char1)
                     section['Ordinal'] = int(m.group(2))
                     section['Name'] = m.group(3)
                     section['Items'] = []
 
+                    rv_section = {
+                        'type': 'SEC',
+                        'asvsId': section['Shortcode'][1:],
+                        'ord': section['Ordinal'],
+                        'heading': section['Name'],
+                        'children': []
+                    }
+
                     chapters.append(chapter)
+                    rv_chapters.append(rv_chapter)
+
+                rv_chapter_help_lines = []
+                rv_section_help_lines = []
+                rv_help_dest = None
+                def rv_push_help_line(line):
+                    if rv_help_dest and line and not line.startswith("| # |") and line.count(":---") < 6:
+                        arr = rv_chapter_help_lines if rv_help_dest == 'chapter' else rv_section_help_lines
+                        arr.append(line)
+                def rv_render_help():
+                    if not rv_help_dest:
+                        return
+                    arr = rv_chapter_help_lines if rv_help_dest == 'chapter' else rv_section_help_lines
+                    if not arr:
+                        return
+                    lines = "".join(arr)
+                    arr.clear()
+                    help_text = self.rv_html(gfm(lines), True)
+                    if rv_help_dest == 'chapter':
+                        rv_chapter['help'] = rv_chapter.get('help', '') + help_text
+                    else:
+                        rv_section['help'] = rv_section.get('help', '') + help_text
 
                 for line in open(os.path.join(self.language, file), encoding="utf8"):
-                    regex = re.compile("^#\s(" + prefix_char1 + "([0-9]{1,2})" + prefix_char1_b + ")\s([\w\s][^\n]*)")
-                    
+                    found_regex = False
+                    regex = re.compile(r"^#\s(" + prefix_char1 + "([0-9]{1,2})" + prefix_char1_b + r")\s([\w\s][^\n]*)")
                     #if line.startswith('# '):
                     #    print(line)
                     m = re.search(regex, line)
                     if m:
+                        rv_render_help()
+                        rv_help_dest = 'chapter'
+                        found_regex = True
                         chapter['Name'] = m.group(3)
+                        rv_chapter['heading'] = chapter['Name']
 
-
-                    regex = re.compile("## (" + prefix_char2 + "[0-9]{1,2}.([0-9]{1,3})) ([\w\s][^\n]*)")
+                    regex = re.compile("## (" + prefix_char2 + r"[0-9]{1,2}.([0-9]{1,3})) ([\w\s][^\n]*)")
                     m = re.search(regex, line)
                     if m:
+                        rv_render_help()
+                        rv_help_dest = 'section'
+                        found_regex = True
                         section = {}
                         section['Shortcode'] = m.group(1)
                         section['Ordinal'] = int(m.group(2))
-                        
+
                         if self.language == 'ar':
                             section['Ordinal'] = int(m.group(1).split('.')[0].replace(prefix_char2, ''))
-                        
+
                         section['Name'] = m.group(3)
                         section['Items'] = []
 
-                        chapter['Items'].append(section)
+                        rv_section = {
+                            'type': 'SEC',
+                            'asvsId': section['Shortcode'][1:],
+                            'ord': section['Ordinal'],
+                            'heading': section['Name'],
+                            'children': []
+                        }
 
-                    regex = re.compile("\*\*([\d\.]+)\*\*\s\|\s{0,1}(.*?)\s{0,1}\|(.*?)\|"\
-                                        "(.*?)\|(.*?)\|([0-9,\s]*)\|([A-Z0-9/\s,.]*)\|{0,1}")
+                        chapter['Items'].append(section)
+                        rv_chapter['children'].append(rv_section)
+
+                    regex = re.compile(r"\*\*([\d\.]+)\*\*\s\|\s{0,1}(.*?)\s{0,1}\|(.*?)\|" +
+                                    r"(.*?)\|(.*?)\|([0-9,\s]*)\|([A-Z0-9/\s,.]*)\|{0,1}")
                     m = re.search(regex, line)
                     if m:
-                    
+                        found_regex = True
                         req_flat = {}
                         req_flat2 = {}
                         req_flat2['Section'] = req_flat['chapter_id'] = chapter['Shortcode']
                         req_flat2['Name'] = req_flat['chapter_name'] = chapter['Name']
                         req_flat['section_id'] = section['Shortcode']
                         req_flat['section_name'] = section['Name']
-                        
+
                         req = {}
                         req_flat2['Item'] = req_flat['req_id'] = req['Shortcode'] = prefix_char2 + m.group(1)
                         req['Ordinal'] = int(m.group(1).rsplit('.',1)[1])
@@ -164,7 +318,7 @@ class ASVS:
                         req_flat['level1'] = m.group(3).strip(' ')
                         req_flat['level2'] = m.group(4).strip(' ')
                         req_flat['level3'] = m.group(5).strip(' ')
-                        
+
                         level1['Required'] = m.group(3).strip() != ''
                         req_flat2['L1'] = ('X' if level1['Required'] else '')
                         level2['Required'] = m.group(4).strip() != ''
@@ -184,10 +338,85 @@ class ASVS:
                         req_flat2['CWE'] = req_flat['cwe'] = m.group(6).strip()
                         req['NIST'] = [str(i.strip()) for i in filter(None,m.group(7).strip().split('/'))]
                         req_flat2['NIST'] = req_flat['nist'] = m.group(7).strip()
-                        
+
+                        rv_req = {
+                            'type': 'REQ',
+                            'asvsId': req['Shortcode'][1:],
+                            'ord': req['Ordinal'],
+                            'text': self.rv_html(gfm(req['Description'])),
+                            'applicable': True
+                        }
+                        rv_cwe = ", ".join([f'<a href="https://cwe.mitre.org/data/definitions/{n}.html">{n}</a>' for n in req['CWE']])
+                        if rv_cwe:
+                            rv_req['cwe'] = "<p>" + rv_cwe + "</p>"
+                        rv_nist = " / ".join([f'<a href="{nist_url}#{nist_map.get(s, "")}">{s}</a>' for s in req['NIST']])
+                        if rv_nist:
+                            rv_req['nist'] = "<p>" + rv_nist + "</p>"
+                        if req['Description'].startswith("[DELETED"):
+                            rv_req['deleted'] = True
+                        if level1['Requirement'] == "Optional":
+                            rv_req['l1'] = "OPT"
+                            rv_req['l1text'] = "o"
+                        elif level1['Required']:
+                            rv_req['l1'] = "REQ"
+                            rv_req['l1text'] = level1['Requirement']
+                        else:
+                            rv_req['l1'] = "NREQ"
+
+                        if level2['Requirement'] == "Optional":
+                            rv_req['l2'] = "OPT"
+                            rv_req['l2text'] = "o"
+                        elif level2['Required']:
+                            rv_req['l2'] = "REQ"
+                            rv_req['l2text'] = level2['Requirement']
+                        else:
+                            rv_req['l2'] = "NREQ"
+
+                        if level3['Requirement'] == "Optional":
+                            rv_req['l3'] = "OPT"
+                            rv_req['l3text'] = "o"
+                        elif level3['Required']:
+                            rv_req['l3'] = "REQ"
+                            rv_req['l3text'] = level3['Requirement']
+                        else:
+                            rv_req['l3'] = "NREQ"
+
                         section['Items'].append(req)
+                        rv_section['children'].append(rv_req)
                         self.asvs_flat['requirements'].append(req_flat)
                         self.asvs_flat2['requirements'].append(req_flat2)
+
+                    if not found_regex:
+                        if re.findall(r'^#+\s', line):
+                            rv_render_help()
+                            if rv_help_dest == 'section':
+                                rv_help_dest = 'chapter'
+                        rv_push_help_line(line)
+
+                rv_render_help()
+                rv_help_dest = None
+
+            if re.match(r"0x9\d-", file):
+                rv_level = rv_parse_md(file, rv_stack, rv_level)
+
+
+    def rv_html(self, html, is_help = False):
+        html = html.replace("\n", "")
+        if is_help:
+            def heading_sub(m):
+                tag = 'em' if int(m.group(2)) > 2 else 'strong'
+                if m.group(1):
+                    return f'</{tag}></p>'
+                else:
+                    return f'<p><{tag}>'
+            html = re.sub(r'<(/?)h(\d)>', heading_sub, html)
+        if self.language != "ar":
+            return html.replace('<table>', '<table style="width: 100%;">').strip()
+        def rtl_sub(m):
+            tag = m.group(1)
+            table_width = ' style="width: 100%;"' if tag == "table" else ""
+            return f'<{tag} dir="rtl"{table_width}>'
+        return re.sub(r'<(p|[uo]l|table)>', rtl_sub, html).strip()
 
     def get_prefix(self):
         prefix_char1 = prefix_char2 = 'V'
@@ -197,13 +426,16 @@ class ASVS:
             prefix_char1_b = ':'
             prefix_char2 = 'ق'
 
-        
+
 
         return prefix_char1, prefix_char2, prefix_char1_b
 
     def to_json(self):
         ''' Returns a JSON-formatted string '''
         return json.dumps(self.asvs, indent = 2, sort_keys = False, ensure_ascii=False).strip()
+
+    def to_reqw_json(self):
+        return json.dumps(self.rv, indent = 2, sort_keys = False, ensure_ascii=False).strip()
 
     def to_json_flat(self):
         ''' Returns a JSON-formatted string which is flattened and simpler '''
@@ -220,7 +452,7 @@ class ASVS:
         return xml
     def to_xml(self):
         return dicttoxml(self.asvs, attr_type=False).decode('utf-8')
-        
+
     def to_csv(self):
         ''' Returns CSV '''
         si = StringIO()
@@ -234,16 +466,16 @@ class ASVS:
     def dict_increment(self, dict_obj, dict_key):
         if dict_key not in dict_obj:
             dict_obj[dict_key] = 0
-        
+
         dict_obj[dict_key] += 1
 
         return dict_obj
-    
+
     def summary_total(self, summary):
         total = 0
         for chapter in summary:
             total += summary[chapter]
-        
+
         return total
 
     def summary_string(self, format, summary):
@@ -251,7 +483,7 @@ class ASVS:
 
 
     def verify_csv(self, csv):
-        
+
         prefix_char1, null, null = self.get_prefix()
 
         summary = {}
@@ -299,5 +531,5 @@ class ASVS:
                                     if el_item2_sub.tag == 'Items':
                                         for el_Items2 in el_item2_sub:
                                             summary = self.dict_increment(summary, scode.replace(prefix_char1,''))
-                    
+
         return self.summary_string('xml', summary)

--- a/4.0/tools/export.py
+++ b/4.0/tools/export.py
@@ -33,7 +33,7 @@ from asvs import ASVS
 from cyclonedx import CycloneDX
 
 parser = argparse.ArgumentParser(description='Export the ASVS requirements.')
-parser.add_argument('--format', choices=['json', 'json_flat', 'xml', 'csv', 'cdx_json'], default='json')
+parser.add_argument('--format', choices=['json', 'json_flat', 'xml', 'csv', 'cdx_json', 'reqw_json'], default='json')
 parser.add_argument('--language', default='en')
 parser.add_argument('--verify-only', default=False)
 
@@ -60,5 +60,7 @@ else:
     elif args.format == "cdx_json":
         cdx = CycloneDX(m.to_json())
         print(cdx.to_json())
+    elif args.format == "reqw_json":
+        print(m.to_reqw_json())
     else:
-        print(m.to_json())   
+        print(m.to_json())

--- a/4.0/tools/install_deps.sh
+++ b/4.0/tools/install_deps.sh
@@ -4,3 +4,4 @@ sudo apt install python3 -y
 sudo apt install python3-pip -y
 pip install dicttoxml
 pip install dicttoxml2
+pip install marko

--- a/4.0/tools/requirements.txt
+++ b/4.0/tools/requirements.txt
@@ -1,1 +1,3 @@
 dicttoxml
+dicttoxml2
+marko

--- a/5.0/Makefile
+++ b/5.0/Makefile
@@ -26,6 +26,7 @@ ODT_FILES := $(foreach lang, $(LANGDIRS), $(DISTDIR)/$(lang)/$(TARGETNAME)$(lang
 JSON_FILES := $(foreach lang, $(LANGDIRS), $(DISTDIR)/$(lang)/$(TARGETNAME)$(lang).json)
 JSON_CDX_FILES := $(foreach lang, $(LANGDIRS), $(DISTDIR)/$(lang)/$(TARGETNAME)$(lang).cdx.json)
 JSON_FLAT_FILES := $(foreach lang, $(LANGDIRS), $(DISTDIR)/$(lang)/$(TARGETNAME)$(lang).flat.json)
+JSON_REQW_FILES := $(foreach lang, $(LANGDIRS), $(DISTDIR)/$(lang)/$(TARGETNAME)$(lang).reqw)
 CSV_FILES := $(foreach lang, $(LANGDIRS), $(DISTDIR)/$(lang)/$(TARGETNAME)$(lang).csv)
 XML_FILES := $(foreach lang, $(LANGDIRS), $(DISTDIR)/$(lang)/$(TARGETNAME)$(lang).xml)
 
@@ -54,9 +55,9 @@ PANDOC_ODT_FLAGS= -s \
 				  --columns 10000 \
 				  --reference-doc=./templates/reference.odt
 
-.PHONY: md pdf docx json json_flat cdx_json csv xml odt tex clean rm-build rm-dist
+.PHONY: md pdf docx json json_flat cdx_json reqw_json csv xml odt tex clean rm-build rm-dist
 
-all: $(TARGETS)	pdf docx json json_flat cdx_json csv xml rm-build
+all: $(TARGETS)	pdf docx json json_flat cdx_json reqw_json csv xml rm-build
 
 $(BUILDDIR):
 	mkdir -p $@
@@ -110,6 +111,10 @@ json_flat: $(JSON_FLAT_FILES)
 $(JSON_CDX_FILES): $(SOURCE_FOLDERS) $(DIST_FOLDERS)
 	python3 $(EXPORT_TOOL) --format cdx_json --language "$(subst dist,,$(@D))" > $@
 cdx_json: $(JSON_CDX_FILES)
+
+$(JSON_REQW_FILES): $(SOURCE_FOLDERS) $(DIST_FOLDERS)
+	python3 $(EXPORT_TOOL) --format reqw_json --language "$(subst dist,,$(@D))" > $@
+reqw_json: $(JSON_REQW_FILES)
 
 $(CSV_FILES): $(SOURCE_FOLDERS) $(DIST_FOLDERS)
 	python3 $(EXPORT_TOOL) --format csv --language "$(subst dist,,$(@D))" > $@

--- a/5.0/generate-all.sh
+++ b/5.0/generate-all.sh
@@ -18,6 +18,7 @@ for lang in ${LANGS}; do
 
     python3 tools/export.py --format json --language $lang > "$verslong.json"
     python3 tools/export.py --format cdx_json --language $lang > "$verslong.cdx.json"
+    python3 tools/export.py --format reqw_json --language $lang > "$verslong.reqw"
     python3 tools/export.py --format json --language $lang --verify-only true
 
     python3 tools/export.py --format json_flat --language $lang > "$verslong.flat.json"

--- a/5.0/templates/ReqView-ASVS.reqw
+++ b/5.0/templates/ReqView-ASVS.reqw
@@ -1,0 +1,461 @@
+{
+  "documents": [
+    {
+      "id": "ASVS",
+      "name": "ASVS Security Requirements",
+      "createdOn": "2024-01-27T17:19:33.363Z",
+      "createdBy": {
+        "name": "ReqView",
+        "email": "support@reqview.com",
+        "company": "Eccam s.r.o."
+      },
+      "lastChangedOn": "2024-03-12T13:27:30.125Z",
+      "lastChangedBy": {
+        "name": "ReqView",
+        "email": "support@reqview.com",
+        "company": "Eccam s.r.o."
+      },
+      "data": [
+
+      ],
+      "attributes": {
+        "asvsId": {
+          "name": "ASVS ID",
+          "type": "string"
+        },
+        "applicable": {
+          "name": "Applicable",
+          "type": "bool"
+        },
+        "compliance": {
+          "name": "Compliance Status",
+          "type": "enum",
+          "values": [
+            {
+              "key": "NC",
+              "label": "Non-compliant"
+            },
+            {
+              "key": "PC",
+              "label": "Partially compliant"
+            },
+            {
+              "key": "FC",
+              "label": "Fully compliant"
+            }
+          ]
+        },
+        "cwe": {
+          "name": "CWE",
+          "type": "xhtml"
+        },
+        "evidence": {
+          "name": "Evidence",
+          "type": "xhtml"
+        },
+        "help": {
+          "help": true,
+          "type": "xhtml"
+        },
+        "l1": {
+          "name": "L1",
+          "type": "enum",
+          "values": [
+            {
+              "key": "NREQ",
+              "label": "Not required"
+            },
+            {
+              "key": "OPT",
+              "label": "Recommended, but not required"
+            },
+            {
+              "key": "REQ",
+              "label": "Required"
+            }
+          ]
+        },
+        "l1text": {
+          "name": "L1 Text",
+          "type": "string"
+        },
+        "l2": {
+          "name": "L2",
+          "type": "enum",
+          "values": [
+            {
+              "key": "NREQ",
+              "label": "Not required"
+            },
+            {
+              "key": "OPT",
+              "label": "Recommended, but not required"
+            },
+            {
+              "key": "REQ",
+              "label": "Required"
+            }
+          ]
+        },
+        "l2text": {
+          "name": "L2 Text",
+          "type": "string"
+        },
+        "l3": {
+          "name": "L3",
+          "type": "enum",
+          "values": [
+            {
+              "key": "NREQ",
+              "label": "Not required"
+            },
+            {
+              "key": "OPT",
+              "label": "Recommended, but not required"
+            },
+            {
+              "key": "REQ",
+              "label": "Required"
+            }
+          ]
+        },
+        "l3text": {
+          "name": "L3 Text",
+          "type": "string"
+        },
+        "nist": {
+          "name": "NIST §",
+          "type": "xhtml"
+        },
+        "ord": {
+          "name": "Ordinal",
+          "type": "int"
+        },
+        "owner": {
+          "name": "Owner",
+          "type": "string"
+        },
+        "type": {
+          "name": "Type",
+          "type": "enum",
+          "values": [
+            {
+              "key": "REQ",
+              "label": "Requirement"
+            },
+            {
+              "key": "SEC",
+              "label": "Section"
+            },
+            {
+              "key": "CHAP",
+              "label": "Chapter"
+            },
+            {
+              "key": "INFO",
+              "label": "Information"
+            }
+          ]
+        }
+      },
+      "templateColumns": {
+        "90625096-fec7-42ef-94a9-57d3e6fd5dcf": {
+          "label": "Chapter / Section",
+          "template": "{{#if (eval type \"==\" \"REQ\")}}\n  {{#withParent}}\n    {{#withParent}}\n      {{heading}}\n    {{/withParent}}\n    / {{heading}}\n  {{/withParent}}\n{{/if}}"
+        }
+      },
+      "views": {
+        "Level 1 Compliance": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "templateColumnId": "90625096-fec7-42ef-94a9-57d3e6fd5dcf",
+              "width": 180
+            },
+            {
+              "columnId": "description",
+              "width": 400
+            },
+            {
+              "columnId": "owner",
+              "width": 150
+            },
+            {
+              "columnId": "compliance",
+              "width": 150
+            },
+            {
+              "columnId": "evidence",
+              "width": 220
+            }
+          ],
+          "filter": [
+            [
+              {
+                "attributeId": "type",
+                "criterion": "attribute",
+                "value": "REQ"
+              },
+              {
+                "attributeId": "applicable",
+                "criterion": "attribute",
+                "value": "true"
+              },
+              {
+                "attributeId": "l1",
+                "criterion": "attribute",
+                "not": true,
+                "value": "NREQ"
+              }
+            ]
+          ]
+        },
+        "Level 2 Compliance": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "templateColumnId": "90625096-fec7-42ef-94a9-57d3e6fd5dcf",
+              "width": 180
+            },
+            {
+              "columnId": "description",
+              "width": 400
+            },
+            {
+              "columnId": "owner",
+              "width": 150
+            },
+            {
+              "columnId": "compliance",
+              "width": 150
+            },
+            {
+              "columnId": "evidence",
+              "width": 220
+            }
+          ],
+          "filter": [
+            [
+              {
+                "attributeId": "type",
+                "criterion": "attribute",
+                "value": "REQ"
+              },
+              {
+                "attributeId": "applicable",
+                "criterion": "attribute",
+                "value": "true"
+              },
+              {
+                "attributeId": "l2",
+                "criterion": "attribute",
+                "not": true,
+                "value": "NREQ"
+              }
+            ]
+          ]
+        },
+        "Level 3 Compliance": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "templateColumnId": "90625096-fec7-42ef-94a9-57d3e6fd5dcf",
+              "width": 180
+            },
+            {
+              "columnId": "description",
+              "width": 400
+            },
+            {
+              "columnId": "owner",
+              "width": 150
+            },
+            {
+              "columnId": "compliance",
+              "width": 150
+            },
+            {
+              "columnId": "evidence",
+              "width": 220
+            }
+          ],
+          "filter": [
+            [
+              {
+                "attributeId": "type",
+                "criterion": "attribute",
+                "value": "REQ"
+              },
+              {
+                "attributeId": "applicable",
+                "criterion": "attribute",
+                "value": "true"
+              },
+              {
+                "attributeId": "l3",
+                "criterion": "attribute",
+                "not": true,
+                "value": "NREQ"
+              }
+            ]
+          ]
+        },
+        "Manage": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "columnId": "description",
+              "width": 437
+            },
+            {
+              "columnId": "l1",
+              "width": 80
+            },
+            {
+              "columnId": "l2",
+              "width": 80
+            },
+            {
+              "columnId": "l3",
+              "width": 80
+            },
+            {
+              "columnId": "applicable",
+              "width": 90
+            },
+            {
+              "columnId": "owner",
+              "width": 150
+            },
+            {
+              "columnId": "compliance",
+              "width": 150
+            }
+          ],
+          "filter": [
+            [
+              {
+                "attributeId": "type",
+                "criterion": "attribute",
+                "not": true,
+                "value": "INFO"
+              }
+            ]
+          ]
+        },
+        "Primary": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "type",
+              "width": 110
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "columnId": "description",
+              "width": 550
+            },
+            {
+              "columnId": "l1text",
+              "width": 70
+            },
+            {
+              "columnId": "l2text",
+              "width": 70
+            },
+            {
+              "columnId": "l3text",
+              "width": 70
+            },
+            {
+              "columnId": "cwe",
+              "width": 70
+            },
+            {
+              "columnId": "nist",
+              "width": 120
+            }
+          ],
+          "default": true
+        },
+        "Traceability": {
+          "columns": [
+            {
+              "columnId": "id",
+              "width": 90
+            },
+            {
+              "columnId": "asvsId",
+              "width": 80
+            },
+            {
+              "templateColumnId": "90625096-fec7-42ef-94a9-57d3e6fd5dcf",
+              "width": 180
+            },
+            {
+              "columnId": "description",
+              "width": 450
+            },
+            {
+              "columnId": "links",
+              "width": 450
+            }
+          ],
+          "filter": [
+            [
+              {
+                "attributeId": "applicable",
+                "criterion": "attribute",
+                "value": "true"
+              }
+            ]
+          ]
+        }
+      }
+    }
+  ],
+  "attachments": {
+  },
+  "copyright": [
+    "Copyright © The OWASP Foundation"
+  ],
+  "url": "https://owasp.org/www-project-application-security-verification-standard/",
+  "metadata": {
+    "format": "2.17",
+    "template": "document"
+  }
+}

--- a/5.0/tools/asvs.py
+++ b/5.0/tools/asvs.py
@@ -30,10 +30,14 @@
 import os
 import re
 import json
+import base64
+import urllib.request
+import datetime
 from xml.sax.saxutils import escape
 import csv
 from dicttoxml2 import dicttoxml
 import xml.etree.ElementTree as ET
+from marko.ext.gfm import gfm
 
 try:
     from StringIO import StringIO
@@ -46,9 +50,9 @@ class ASVS:
     asvs['Name'] = "Application Security Verification Standard Project"
     asvs['ShortName'] = "ASVS"
     asvs['Version'] = ""
-    asvs['Description'] = "The OWASP Application Security Verification Standard (ASVS) Project " \
-        "provides a basis for testing web application technical security controls and also " \
-        "provides developers with a list of requirements for secure development."
+    asvs['Description'] = ("The OWASP Application Security Verification Standard (ASVS) Project "
+            "provides a basis for testing web application technical security controls and also "
+            "provides developers with a list of requirements for secure development.")
 
     asvs_flat = {}
     asvs_flat2 = {}
@@ -56,13 +60,15 @@ class ASVS:
     asvs_flat2['requirements'] = []
     language = ''
 
-    def __init__(self, language_in):    
-        
+    rv = json.load(open(os.path.join("templates", "ReqView-ASVS.reqw"), encoding="utf8"))
+
+    def __init__(self, language_in):
+
         self.language = language_in
         prefix_char1, prefix_char2, prefix_char1_b = self.get_prefix()
 
-        regex = re.compile('Version (([\d.]+){3})')
-        
+        regex = re.compile(r'Version (([\d.]+){3})')
+
         for line in open(os.path.join(self.language, "0x01-Frontispiece.md"), encoding="utf8"):
             m = re.search(regex, line)
             if m:
@@ -75,13 +81,89 @@ class ASVS:
             m = re.search(regex, content.read())
             if m:
                 self.asvs['Description'] = m.group(1)
+                self.rv['description'] = m.group(1)
+
+        nist_url = "https://pages.nist.gov/800-63-3/sp800-63b.html"
+        nist_html = urllib.request.urlopen(nist_url).read().decode()
+        nist_headings = ["".join(h) for h in re.findall(r'<h[34]([^>]*)>(.+)</h[34]>', nist_html)]
+        nist_map = {}
+        for h in nist_headings:
+            if secnum := re.findall(r'[1-9A]+\.[0-9\.]+', h):
+                if a_id := re.findall(r'id="(.+)"', h):
+                    nist_map[secnum[0]] = a_id[0]
+                if a_name := re.findall(r'name="(.+)"', h):
+                    nist_map[secnum[0]] = a_name[0]
 
         self.asvs['Requirements'] = chapters = []
+        rv_doc = self.rv['documents'][0]
+        timestamp = datetime.datetime.now(datetime.UTC).isoformat(timespec='milliseconds')[:-6] + "Z"
+        rv_doc['createdOn'] = rv_doc['lastChangedOn'] = timestamp
 
-    
+        rv_chapters = rv_doc['data'] = []
+        if self.language == 'ar':
+            rv_doc['rtl'] = True
+
+        self.rv['attachments'] = {}
+        rv_stack = [rv_chapters]
+
+        rv_level = 0
+
+        def rv_parse_md(file, stack, level):
+            doc = gfm.parse(open(os.path.join(self.language, file), encoding="utf8").read())
+            obj = None
+            for e in doc.children:
+                t = e.get_type()
+                if t == "Heading":
+                    if not e.children:
+                        continue
+                    h_obj = {
+                        'heading': e.children[0].children,
+                        'children': [],
+                        'type': 'INFO'
+                    }
+                    obj = None
+                    if e.level > level:
+                        level += 1
+                    else:
+                        while e.level < level:
+                            stack.pop()
+                            level -= 1
+                        if e.level == level:
+                            stack.pop()
+                    stack[-1].append(h_obj)
+                    stack.append(h_obj['children'])
+                elif t != "BlankLine":
+                    if obj is None:
+                        obj = {
+                            'text': "",
+                            'type': 'INFO'
+                        }
+                        stack[-1].append(obj)
+                    if e.children:
+                        for img in [c for c in e.children if c.get_type() == "Image"]:
+                            if img.dest.startswith("https://"):
+                                stream = urllib.request.urlopen(img.dest)
+                            else:
+                                stream = open(os.path.join(self.language, img.dest), "rb")
+                            att_id = os.path.basename(img.dest)
+                            if 'attachments' not in obj:
+                                obj['attachments'] = []
+                            obj['attachments'].append(att_id)
+                            b64_data = base64.b64encode(stream.read())
+                            self.rv['attachments'][att_id] = {'data': f"data:image/png;base64,{b64_data.decode()}"}
+
+                        e.children = [c for c in e.children if c.get_type() != "Image"]
+                    html = gfm.render(e)
+                    if html and html != "<p></p>\n":
+                        obj['text'] += self.rv_html(html)
+            return level
+
         for file in sorted(os.listdir(self.language)):
 
-            if re.match("0x\d{2}-V", file):
+            if re.match(r"0x0\d-.+\.md$", file):
+                rv_level = rv_parse_md(file, rv_stack, rv_level)
+
+            if re.match(r"0x\d{2}-V", file):
                 chapter = {}
                 chapter['Shortcode'] = ""
                 chapter['Ordinal'] = ""
@@ -89,13 +171,31 @@ class ASVS:
                 chapter['Name'] = ""
                 chapter['Items'] = []
 
+                # never used by rv
+                rv_chapter = {
+                    'type': 'CHAP',
+                    'asvsId': "",
+                    'ord': "",
+                    'heading': "",  # ShortName
+                    'children': []
+                }
+
                 section = {}
                 section['Shortcode'] = ""
                 section['Ordinal'] = ""
                 section['Name'] = ""
                 section['Items'] = []
 
-                regex = re.compile('0x\d{2}-(V([0-9]{1,3}))-(\w[^-.]*)')
+                # never used by rv
+                rv_section = {
+                    'type': 'SEC',
+                    'shortcode': "",
+                    'ord': "",
+                    'heading': "",  # Name
+                    'children': []
+                }
+
+                regex = re.compile(r'0x\d{2}-(V([0-9]{1,3}))-(\w[^-.]*)')
                 m = re.search(regex, file)
                 if m:
                     chapter = {}
@@ -105,51 +205,104 @@ class ASVS:
                     chapter['Name'] = ""
                     chapter['Items'] = []
 
+                    rv_chapter = {
+                        'type': 'CHAP',
+                        'asvsId': chapter['Shortcode'][1:],
+                        'ord': chapter['Ordinal'],
+                        'heading': chapter['ShortName'],
+                        'children': []
+                    }
+
                     section = {}
                     section['Shortcode'] = m.group(1).replace('V', prefix_char1)
                     section['Ordinal'] = int(m.group(2))
                     section['Name'] = m.group(3)
                     section['Items'] = []
 
+                    rv_section = {
+                        'type': 'SEC',
+                        'asvsId': section['Shortcode'][1:],
+                        'ord': section['Ordinal'],
+                        'heading': section['Name'],
+                        'children': []
+                    }
+
                     chapters.append(chapter)
+                    rv_chapters.append(rv_chapter)
+
+                rv_chapter_help_lines = []
+                rv_section_help_lines = []
+                rv_help_dest = None
+                def rv_push_help_line(line):
+                    if rv_help_dest and line and not line.startswith("| # |") and line.count(":---") < 6:
+                        arr = rv_chapter_help_lines if rv_help_dest == 'chapter' else rv_section_help_lines
+                        arr.append(line)
+                def rv_render_help():
+                    if not rv_help_dest:
+                        return
+                    arr = rv_chapter_help_lines if rv_help_dest == 'chapter' else rv_section_help_lines
+                    if not arr:
+                        return
+                    lines = "".join(arr)
+                    arr.clear()
+                    help_text = self.rv_html(gfm(lines), True)
+                    if rv_help_dest == 'chapter':
+                        rv_chapter['help'] = rv_chapter.get('help', '') + help_text
+                    else:
+                        rv_section['help'] = rv_section.get('help', '') + help_text
 
                 for line in open(os.path.join(self.language, file), encoding="utf8"):
-                    regex = re.compile("^#\s(" + prefix_char1 + "([0-9]{1,2})" + prefix_char1_b + ")\s([\w\s][^\n]*)")
-                    
+                    found_regex = False
+                    regex = re.compile(r"^#\s(" + prefix_char1 + "([0-9]{1,2})" + prefix_char1_b + r")\s([\w\s][^\n]*)")
                     #if line.startswith('# '):
                     #    print(line)
                     m = re.search(regex, line)
                     if m:
+                        rv_render_help()
+                        rv_help_dest = 'chapter'
+                        found_regex = True
                         chapter['Name'] = m.group(3)
+                        rv_chapter['heading'] = chapter['Name']
 
-
-                    regex = re.compile("## (" + prefix_char2 + "[0-9]{1,2}.([0-9]{1,3})) ([\w\s][^\n]*)")
+                    regex = re.compile("## (" + prefix_char2 + r"[0-9]{1,2}.([0-9]{1,3})) ([\w\s][^\n]*)")
                     m = re.search(regex, line)
                     if m:
+                        rv_render_help()
+                        rv_help_dest = 'section'
+                        found_regex = True
                         section = {}
                         section['Shortcode'] = m.group(1)
                         section['Ordinal'] = int(m.group(2))
-                        
+
                         if self.language == 'ar':
                             section['Ordinal'] = int(m.group(1).split('.')[0].replace(prefix_char2, ''))
-                        
+
                         section['Name'] = m.group(3)
                         section['Items'] = []
 
-                        chapter['Items'].append(section)
+                        rv_section = {
+                            'type': 'SEC',
+                            'asvsId': section['Shortcode'][1:],
+                            'ord': section['Ordinal'],
+                            'heading': section['Name'],
+                            'children': []
+                        }
 
-                    regex = re.compile("\*\*([\d\.]+)\*\*\s\|\s{0,1}(.*?)\s{0,1}\|(.*?)\|"\
-                                        "(.*?)\|(.*?)\|([0-9,\s]*)\|([A-Z0-9/\s,.]*)\|{0,1}")
+                        chapter['Items'].append(section)
+                        rv_chapter['children'].append(rv_section)
+
+                    regex = re.compile(r"\*\*([\d\.]+)\*\*\s\|\s{0,1}(.*?)\s{0,1}\|(.*?)\|" +
+                                    r"(.*?)\|(.*?)\|([0-9,\s]*)\|([A-Z0-9/\s,.]*)\|{0,1}")
                     m = re.search(regex, line)
                     if m:
-                    
+                        found_regex = True
                         req_flat = {}
                         req_flat2 = {}
                         req_flat2['Section'] = req_flat['chapter_id'] = chapter['Shortcode']
                         req_flat2['Name'] = req_flat['chapter_name'] = chapter['Name']
                         req_flat['section_id'] = section['Shortcode']
                         req_flat['section_name'] = section['Name']
-                        
+
                         req = {}
                         req_flat2['Item'] = req_flat['req_id'] = req['Shortcode'] = prefix_char2 + m.group(1)
                         req['Ordinal'] = int(m.group(1).rsplit('.',1)[1])
@@ -165,7 +318,7 @@ class ASVS:
                         req_flat['level1'] = m.group(3).strip(' ')
                         req_flat['level2'] = m.group(4).strip(' ')
                         req_flat['level3'] = m.group(5).strip(' ')
-                        
+
                         level1['Required'] = m.group(3).strip() != ''
                         req_flat2['L1'] = ('X' if level1['Required'] else '')
                         level2['Required'] = m.group(4).strip() != ''
@@ -185,10 +338,85 @@ class ASVS:
                         req_flat2['CWE'] = req_flat['cwe'] = m.group(6).strip()
                         req['NIST'] = [str(i.strip()) for i in filter(None,m.group(7).strip().split('/'))]
                         req_flat2['NIST'] = req_flat['nist'] = m.group(7).strip()
-                        
+
+                        rv_req = {
+                            'type': 'REQ',
+                            'asvsId': req['Shortcode'][1:],
+                            'ord': req['Ordinal'],
+                            'text': self.rv_html(gfm(req['Description'])),
+                            'applicable': True
+                        }
+                        rv_cwe = ", ".join([f'<a href="https://cwe.mitre.org/data/definitions/{n}.html">{n}</a>' for n in req['CWE']])
+                        if rv_cwe:
+                            rv_req['cwe'] = "<p>" + rv_cwe + "</p>"
+                        rv_nist = " / ".join([f'<a href="{nist_url}#{nist_map.get(s, "")}">{s}</a>' for s in req['NIST']])
+                        if rv_nist:
+                            rv_req['nist'] = "<p>" + rv_nist + "</p>"
+                        if req['Description'].startswith("[DELETED"):
+                            rv_req['deleted'] = True
+                        if level1['Requirement'] == "Optional":
+                            rv_req['l1'] = "OPT"
+                            rv_req['l1text'] = "o"
+                        elif level1['Required']:
+                            rv_req['l1'] = "REQ"
+                            rv_req['l1text'] = level1['Requirement']
+                        else:
+                            rv_req['l1'] = "NREQ"
+
+                        if level2['Requirement'] == "Optional":
+                            rv_req['l2'] = "OPT"
+                            rv_req['l2text'] = "o"
+                        elif level2['Required']:
+                            rv_req['l2'] = "REQ"
+                            rv_req['l2text'] = level2['Requirement']
+                        else:
+                            rv_req['l2'] = "NREQ"
+
+                        if level3['Requirement'] == "Optional":
+                            rv_req['l3'] = "OPT"
+                            rv_req['l3text'] = "o"
+                        elif level3['Required']:
+                            rv_req['l3'] = "REQ"
+                            rv_req['l3text'] = level3['Requirement']
+                        else:
+                            rv_req['l3'] = "NREQ"
+
                         section['Items'].append(req)
+                        rv_section['children'].append(rv_req)
                         self.asvs_flat['requirements'].append(req_flat)
                         self.asvs_flat2['requirements'].append(req_flat2)
+
+                    if not found_regex:
+                        if re.findall(r'^#+\s', line):
+                            rv_render_help()
+                            if rv_help_dest == 'section':
+                                rv_help_dest = 'chapter'
+                        rv_push_help_line(line)
+
+                rv_render_help()
+                rv_help_dest = None
+
+            if re.match(r"0x9\d-", file):
+                rv_level = rv_parse_md(file, rv_stack, rv_level)
+
+
+    def rv_html(self, html, is_help = False):
+        html = html.replace("\n", "")
+        if is_help:
+            def heading_sub(m):
+                tag = 'em' if int(m.group(2)) > 2 else 'strong'
+                if m.group(1):
+                    return f'</{tag}></p>'
+                else:
+                    return f'<p><{tag}>'
+            html = re.sub(r'<(/?)h(\d)>', heading_sub, html)
+        if self.language != "ar":
+            return html.replace('<table>', '<table style="width: 100%;">').strip()
+        def rtl_sub(m):
+            tag = m.group(1)
+            table_width = ' style="width: 100%;"' if tag == "table" else ""
+            return f'<{tag} dir="rtl"{table_width}>'
+        return re.sub(r'<(p|[uo]l|table)>', rtl_sub, html).strip()
 
     def get_prefix(self):
         prefix_char1 = prefix_char2 = 'V'
@@ -198,13 +426,16 @@ class ASVS:
             prefix_char1_b = ':'
             prefix_char2 = 'ق'
 
-        
+
 
         return prefix_char1, prefix_char2, prefix_char1_b
 
     def to_json(self):
         ''' Returns a JSON-formatted string '''
         return json.dumps(self.asvs, indent = 2, sort_keys = False, ensure_ascii=False).strip()
+
+    def to_reqw_json(self):
+        return json.dumps(self.rv, indent = 2, sort_keys = False, ensure_ascii=False).strip()
 
     def to_json_flat(self):
         ''' Returns a JSON-formatted string which is flattened and simpler '''
@@ -221,7 +452,7 @@ class ASVS:
         return xml
     def to_xml(self):
         return dicttoxml(self.asvs, attr_type=False).decode('utf-8')
-        
+
     def to_csv(self):
         ''' Returns CSV '''
         si = StringIO()
@@ -235,16 +466,16 @@ class ASVS:
     def dict_increment(self, dict_obj, dict_key):
         if dict_key not in dict_obj:
             dict_obj[dict_key] = 0
-        
+
         dict_obj[dict_key] += 1
 
         return dict_obj
-    
+
     def summary_total(self, summary):
         total = 0
         for chapter in summary:
             total += summary[chapter]
-        
+
         return total
 
     def summary_string(self, format, summary):
@@ -252,7 +483,7 @@ class ASVS:
 
 
     def verify_csv(self, csv):
-        
+
         prefix_char1, null, null = self.get_prefix()
 
         summary = {}
@@ -300,5 +531,5 @@ class ASVS:
                                     if el_item2_sub.tag == 'Items':
                                         for el_Items2 in el_item2_sub:
                                             summary = self.dict_increment(summary, scode.replace(prefix_char1,''))
-                    
+
         return self.summary_string('xml', summary)

--- a/5.0/tools/export.py
+++ b/5.0/tools/export.py
@@ -33,7 +33,7 @@ from asvs import ASVS
 from cyclonedx import CycloneDX
 
 parser = argparse.ArgumentParser(description='Export the ASVS requirements.')
-parser.add_argument('--format', choices=['json', 'json_flat', 'xml', 'csv', 'cdx_json'], default='json')
+parser.add_argument('--format', choices=['json', 'json_flat', 'xml', 'csv', 'cdx_json', 'reqw_json'], default='json')
 parser.add_argument('--language', default='en')
 parser.add_argument('--verify-only', default=False)
 
@@ -60,5 +60,7 @@ else:
     elif args.format == "cdx_json":
         cdx = CycloneDX(m.to_json())
         print(cdx.to_json())
+    elif args.format == "reqw_json":
+        print(m.to_reqw_json())
     else:
-        print(m.to_json())   
+        print(m.to_json())

--- a/5.0/tools/install_deps.sh
+++ b/5.0/tools/install_deps.sh
@@ -4,3 +4,4 @@ sudo apt install python3 -y
 sudo apt install python3-pip -y
 pip install dicttoxml
 pip install dicttoxml2
+pip install marko

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,7 @@ FROM base_${WITH_CERT} as pandoc_base
 ENV PATH /root/.py-env:$PATH
 RUN python3 -m venv /root/.py-env --system-site-packages
 RUN /root/.py-env/bin/pip install --upgrade pip 
-RUN /root/.py-env/bin/pip install dicttoxml2 setuptools==69.0.3 
+RUN /root/.py-env/bin/pip install dicttoxml2 marko setuptools==69.0.3
 
 #install Pandoc
 RUN adduser -s /bin/bash -g "pandoc" -D pandoc


### PR DESCRIPTION
<!---
IMPORTANT NOTES:
- Changes should always be made only in the raw .md files and not in the CSV, JSON, XLSX, PDF, DOCX files, etc.
- Please do not open a pull request without first opening an associated issue.
- Please carry out all discussion in the associated issue only.
- Please refer to the following link for guidance on labeling contributions https://github.com/OWASP/ASVS/blob/master/CONTRIBUTING.md#standard-for-changes
-->
This code adds support for generating ReqView document templates (.reqw) from the source .md files. It’s mostly an extension of the existing JSON generators for both 4.0 and 5.0 (they remain identical), because the structure of the output is very similar to the already generated JSON.

Basically, a template ReqView JSON file is read and filled with data from the .md files. Some additional Markdown processing is done to be able to separate the informative text from the actual requirements’ text, and also HTML is rendered from the processed bits.

The generated outputs for v4.0.3 can be found at [ReqView docs site](https://www.reqview.com/doc/asvs-template/#document-template), current v5.0 is available as [OWASP_Application_Security_Verification_Standard-5_en.zip](https://github.com/OWASP/ASVS/files/15080030/OWASP_Application_Security_Verification_Standard-5_en.zip).

This Pull Request relates to issue #1938, where I’ve tried to explain the use case for generating this format.