### PR TITLE
Fix URL redirect

### DIFF
--- a/5.0/en/0x16-V8-Data-Protection.md
+++ b/5.0/en/0x16-V8-Data-Protection.md
@@ -66,7 +66,7 @@ For more information, see also:
 * [OWASP Secure Headers project](https://owasp.org/www-project-secure-headers/)
 * [OWASP Privacy Risks Project](https://owasp.org/www-project-top-10-privacy-risks/)
 * [OWASP User Privacy Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/User_Privacy_Protection_Cheat_Sheet.html)
-* [Australian Privacy Principle 11 - Security of personal information](https://www.oaic.gov.au/privacy/australian-privacy-principles-guidelines/chapter-11-app-11-security-of-personal-information)
+* [Australian Privacy Principle 11 - Security of personal information](https://www.oaic.gov.au/privacy/australian-privacy-principles/australian-privacy-principles-guidelines/chapter-11-app-11-security-of-personal-information)
 * [European Union General Data Protection Regulation (GDPR) overview](https://www.edps.europa.eu/data-protection_en)
 * [European Union Data Protection Supervisor - Internet Privacy Engineering Network](https://www.edps.europa.eu/data-protection/ipen-internet-privacy-engineering-network_en)
 * [Information on the "Clear-Site-Data" header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data)


### PR DESCRIPTION
<!---
IMPORTANT NOTES:
- Changes should always be made only in the raw .md files and not in the CSV, JSON, XLSX, PDF, DOCX files, etc.
- Please do not open a pull request without first opening an associated issue.
- Please carry out all discussion in the associated issue only.
- Please refer to the following link for guidance on labeling contributions https://github.com/OWASP/ASVS/blob/master/CONTRIBUTING.md#standard-for-changes
-->

Related to https://github.com/OWASP/ASVS/issues/1990

It seems the link checker is not temperamental but is just doing its work. The problematic link doesn't return expected `200` but instead is a redirect. I tested it in my fork and [it worked](https://github.com/arkid15r/owasp-asvs/actions/runs/10581325636/job/29318321873).

As for the rest of the issue -- I think it's worth researching available markdown link check solutions as the current one is deprecated. My understanding it's just a wrapper around [markdown-link-check package](https://github.com/gaurav-nelson/github-action-markdown-link-check/blob/5c5dfc0ac2e225883c0e5f03a85311ec2830d368/entrypoint.sh#L11C10-L11C29).

It'd be a good staring point to decide whether redirects should be treated as accepted status codes.

I can look into addressing the rest of the #1990 if you'd like.
