### PR TITLE
1.4.6 - Contextual attributes for access control decisions

### DIFF
--- a/5.0/en/0x10-V1-Architecture.md
+++ b/5.0/en/0x10-V1-Architecture.md
@@ -47,6 +47,7 @@ This is a placeholder for future architectural requirements.
 | **1.4.3** | [DELETED, DUPLICATE OF 4.1.3] | | | | |
 | **1.4.4** | Verify the application uses a single and well-vetted access control mechanism for accessing protected data and resources. All requests must pass through this single mechanism to avoid copy and paste or insecure alternative paths. | | ✓ | ✓ | 284 |
 | **1.4.5** | [GRAMMAR] Verify that attribute or feature-based access control is used whereby the code checks the user's authorization for a feature or data item rather than just their role. Permissions should still be allocated using roles. | | ✓ | ✓ | 275 |
+| **1.4.6** | [ADDED] Verify that the application documentation defines controls which use changes to a user's regular environmental and contextual attributes (such as time of day, location, IP address, or device) to make security decisions, including those pertaining to authentication and authorization. | | | ✓ | 1120 |
 
 ## V1.5 Input and Output Architecture
 

--- a/5.0/en/0x10-V1-Architecture.md
+++ b/5.0/en/0x10-V1-Architecture.md
@@ -47,7 +47,7 @@ This is a placeholder for future architectural requirements.
 | **1.4.3** | [DELETED, DUPLICATE OF 4.1.3] | | | | |
 | **1.4.4** | Verify the application uses a single and well-vetted access control mechanism for accessing protected data and resources. All requests must pass through this single mechanism to avoid copy and paste or insecure alternative paths. | | ✓ | ✓ | 284 |
 | **1.4.5** | [GRAMMAR] Verify that attribute or feature-based access control is used whereby the code checks the user's authorization for a feature or data item rather than just their role. Permissions should still be allocated using roles. | | ✓ | ✓ | 275 |
-| **1.4.6** | [ADDED] Verify that the application documentation defines controls which use changes to a user's regular environmental and contextual attributes (such as time of day, location, IP address, or device) to make security decisions, including those pertaining to authentication and authorization. | | | ✓ | 1120 |
+| **1.4.6** | [ADDED] Verify that the application documentation defines controls which use changes to a user's regular environmental and contextual attributes (such as time of day, location, IP address, or device) to make security decisions, including those pertaining to authentication and authorization. | | | ✓ | |
 
 ## V1.5 Input and Output Architecture
 


### PR DESCRIPTION
Adding requirement in 1.4 calling for the consideration of changes in environmental or contextual attributes when making security decisions for L3 applications.

This Pull Request relates to issue #2062 
