### PR TITLE
Requirement for access control documentation

### DIFF
--- a/5.0/en/0x10-V1-Architecture.md
+++ b/5.0/en/0x10-V1-Architecture.md
@@ -48,7 +48,7 @@ This is a placeholder for future architectural requirements.
 | **1.4.4** | Verify the application uses a single and well-vetted access control mechanism for accessing protected data and resources. All requests must pass through this single mechanism to avoid copy and paste or insecure alternative paths. | | ✓ | ✓ | 284 |
 | **1.4.5** | [GRAMMAR] Verify that attribute or feature-based access control is used whereby the code checks the user's authorization for a feature or data item rather than just their role. Permissions should still be allocated using roles. | | ✓ | ✓ | 275 |
 | **1.4.6** | [ADDED] Verify that the application documentation defines controls which use changes to a user's regular environmental and contextual attributes (such as time of day, location, IP address, or device) to make security decisions, including those pertaining to authentication and authorization. These changes should be detected both when the user tries to start a new session and also in the course of an existing session. | | | ✓ | |
-| **1.4.7** | Verify that access control documentation defines the rules for access control decision-making, specifying user and subject attributes, resource attributes, and relevant environmental factors involved in the process. | ✓ | ✓ | ✓ | 284 |
+| **1.4.7** | [ADDED] Verify that access control documentation defines the rules for access control decision-making, specifying user and subject attributes, resource attributes, and relevant environmental factors involved in the process. | ✓ | ✓ | ✓ | |
 
 ## V1.5 Input and Output Architecture
 

--- a/5.0/en/0x10-V1-Architecture.md
+++ b/5.0/en/0x10-V1-Architecture.md
@@ -48,6 +48,7 @@ This is a placeholder for future architectural requirements.
 | **1.4.4** | Verify the application uses a single and well-vetted access control mechanism for accessing protected data and resources. All requests must pass through this single mechanism to avoid copy and paste or insecure alternative paths. | | ✓ | ✓ | 284 |
 | **1.4.5** | [GRAMMAR] Verify that attribute or feature-based access control is used whereby the code checks the user's authorization for a feature or data item rather than just their role. Permissions should still be allocated using roles. | | ✓ | ✓ | 275 |
 | **1.4.6** | [ADDED] Verify that the application documentation defines controls which use changes to a user's regular environmental and contextual attributes (such as time of day, location, IP address, or device) to make security decisions, including those pertaining to authentication and authorization. These changes should be detected both when the user tries to start a new session and also in the course of an existing session. | | | ✓ | |
+| **1.4.7** | Verify that access control documentation defines the rules for access control decision-making, specifying user and subject attributes, resource attributes, and relevant environmental factors involved in the process. | ✓ | ✓ | ✓ | 284 |
 
 ## V1.5 Input and Output Architecture
 


### PR DESCRIPTION
Added 1.4.7, a requirement for access control documentation

This Pull Request relates to issue #2065 
