### PR TITLE
Add 4.2.4 - addressing access control by originating subject

### DIFF
--- a/5.0/en/0x12-V4-Access-Control.md
+++ b/5.0/en/0x12-V4-Access-Control.md
@@ -27,6 +27,7 @@ Access control deficiencies are unlikely to be discovered using generic automate
 | **4.2.1** | Verify that sensitive data and APIs are protected against Insecure Direct Object Reference (IDOR) attacks targeting creation, reading, updating and deletion of records, such as creating or updating someone else's record, viewing everyone's records, or deleting all records. | ✓ | ✓ | ✓ | 639 |
 | **4.2.2** | [MOVED TO 50.3.1] | | | | |
 | **4.2.3** | [ADDED] Verify that multi-tenant applications use cross-tenant controls to ensure user operations will never affect tenants with which they do not have permissions to interact. | ✓ | ✓ | ✓ | 283 |
+| **4.2.4** | [ADDED] Verify that access to an object is based on the originating subject's (e.g. user's) permissions, not on the permissions of any intermediary or service acting on their behalf. | | | ✓ | 441 |
 
 ## V4.3 Other Access Control Considerations
 

--- a/5.0/en/0x12-V4-Access-Control.md
+++ b/5.0/en/0x12-V4-Access-Control.md
@@ -27,7 +27,7 @@ Access control deficiencies are unlikely to be discovered using generic automate
 | **4.2.1** | Verify that sensitive data and APIs are protected against Insecure Direct Object Reference (IDOR) attacks targeting creation, reading, updating and deletion of records, such as creating or updating someone else's record, viewing everyone's records, or deleting all records. | ✓ | ✓ | ✓ | 639 |
 | **4.2.2** | [MOVED TO 50.3.1] | | | | |
 | **4.2.3** | [ADDED] Verify that multi-tenant applications use cross-tenant controls to ensure user operations will never affect tenants with which they do not have permissions to interact. | ✓ | ✓ | ✓ | 283 |
-| **4.2.4** | [ADDED] Verify that access to an object is based on the originating subject's (e.g. user's) permissions, not on the permissions of any intermediary or service acting on their behalf. | | | ✓ | 441 |
+| **4.2.4** | [ADDED] Verify that access to an object is based on the originating subject's (e.g. user's) permissions, not on the permissions of any intermediary or service acting on their behalf. For example, if a user calls a web service using a signed token for authentication, and the service then requests data from a different service, the second service should use the user's signed token, rather than a machine-to-machine token from the first service, to make permission decisions. | | | ✓ | 441 |
 
 ## V4.3 Other Access Control Considerations
 


### PR DESCRIPTION
This Pull Request relates to issue #2061, addressing the use of originating subject's permissions and not those of an intermediary.
