### PR TITLE
Consider 403 to be an alive link

### DIFF
--- a/.github/workflows/config/url-checker-config.json
+++ b/.github/workflows/config/url-checker-config.json
@@ -16,6 +16,7 @@
         }
     ],
     "retryOn429": true,
+    "aliveStatusCodes": [403],
     "fallbackRetryDelay": "30s",
     "see": "https://github.com/tcort/markdown-link-check#config-file-format"
 }


### PR DESCRIPTION
<https://securityheaders.com/> is protected by cloudflare which means that when trying to access it, there is some anti-bot stuff that happens first which (amongst other things) means that the first response to calling the link is HTTP 403 and not a more successful response. This breaks the link checker.

As noted in this comment: https://github.com/OWASP/ASVS/issues/1990#issuecomment-2433144923, we can add 403 to the list of acceptable status codes. This seems reasonable as it means the link is alive but for some reason not accessible but it is unlikely to be for any reason other than this one.

This PR adds 403 to the alive list