### PR TITLE
amended 6.6.2 to reflect argon2ID and parameters, edited text to be m…

### DIFF
--- a/5.0/en/0x11-V2-Authentication.md
+++ b/5.0/en/0x11-V2-Authentication.md
@@ -97,7 +97,7 @@ In particular, note that since these algorithms are intentionally compute-intens
 
 | # | Description | L1 | L2 | L3 | CWE | [NIST &sect;](https://pages.nist.gov/800-63-3/sp800-63b.html) |
 | :---: | :--- | :---: | :---: | :---: | :---: | :---: |
-| **2.4.1** | [DELETED, MOVED TO 6.6.2] | | | | | |
+| **2.4.1** | [MOVED TO 6.6.2] | | | | | |
 | **2.4.2** | [DELETED, INCORRECT] | | | | | |
 | **2.4.3** | [DELETED, MERGED TO 2.4.1] | | | | | |
 | **2.4.4** | [DELETED, MERGED TO 2.4.1] | | | | | |

--- a/5.0/en/0x11-V2-Authentication.md
+++ b/5.0/en/0x11-V2-Authentication.md
@@ -97,7 +97,7 @@ In particular, note that since these algorithms are intentionally compute-intens
 
 | # | Description | L1 | L2 | L3 | CWE | [NIST &sect;](https://pages.nist.gov/800-63-3/sp800-63b.html) |
 | :---: | :--- | :---: | :---: | :---: | :---: | :---: |
-| **2.4.1** | [MODIFIED, MERGED FROM 2.4.3, 2.4.4] Verify that user passwords are stored using an approved password hashing algorithm that is securely configured according to current guidance. | | ✓ | ✓ | 916 | 5.1.1.2 |
+| **2.4.1** | [DELETED, MOVED TO 6.6.2] | | | | | |
 | **2.4.2** | [DELETED, INCORRECT] | | | | | |
 | **2.4.3** | [DELETED, MERGED TO 2.4.1] | | | | | |
 | **2.4.4** | [DELETED, MERGED TO 2.4.1] | | | | | |

--- a/5.0/en/0x14-V6-Cryptography.md
+++ b/5.0/en/0x14-V6-Cryptography.md
@@ -6,7 +6,7 @@ The objective of V6 is not only to define best practices but also to instill a f
 
 * Implementing robust cryptographic systems that fail securely, adapt to evolving threats, and are future-proof.
 * Utilizing cryptographic mechanisms that are both secure and aligned with industry best practices.
-* Maintaining a secure crypv6tographic key management system with appropriate access controls and auditing.
+* Maintaining a secure cryptographic key management system with appropriate access controls and auditing.
 * Regularly evaluating the cryptographic landscape to assess new risks and adapt algorithms accordingly.
 * Discovering and managing cryptographic use cases throughout the application's lifecycle to ensure that all cryptographic assets are accounted for and secured.
 
@@ -193,7 +193,7 @@ Cryptographic hashes are used in a wide variety of cryptographic protocols, such
 | # | Description | L1 | L2 | L3 | CWE |
 | :---: | :--- | :---: | :---: | :---: | :---: |
 | **6.6.1** | [ADDED] Verify that only approved hash functions are used for general cryptographic use cases, including digital signatures, HMAC, KDF, and random bit generation. Approved hash functions are listed below. | | ✓ | ✓ | 916 |
-| **6.6.2** | [ADDED] Verify that passwords are stored using a slow, computationally intensive hashing algorithm with recommended parameter settings, as outlined below, that balance security and performance to make brute-force attacks more challenging. | | ✓ | ✓ | 916 |
+| **6.6.2** | [ADDED] Verify that passwords are stored using an approved, computationally intensive, hashing algorithm with parameter settings configured based on current guidance. The settings should balance security and performance to make brute-force attacks more challenging. | | ✓ | ✓ | 916 |
 | **6.6.3** | [ADDED] Verify that cryptographic systems avoid the use of disallowed hash functions, such as MD5, SHA-1, or any other insecure hash functions, for any cryptographic purpose. | ✓ | ✓ | ✓ | 327 |
 | **6.6.4** | [ADDED] Verify that hash functions used in digital signatures are collision resistant and have appropriate bit-lengths to avoid attacks, such as collision or pre-image attacks. | ✓ | ✓ | ✓ | 916 |
 | **6.6.5** | [ADDED] Verify that hash functions used in HMAC, KDF, and random bit generation are derived from those with proper entropy seeding for random bit generation. | | ✓ | ✓ | 916 |

--- a/5.0/en/0x14-V6-Cryptography.md
+++ b/5.0/en/0x14-V6-Cryptography.md
@@ -6,7 +6,7 @@ The objective of V6 is not only to define best practices but also to instill a f
 
 * Implementing robust cryptographic systems that fail securely, adapt to evolving threats, and are future-proof.
 * Utilizing cryptographic mechanisms that are both secure and aligned with industry best practices.
-* Maintaining a secure cryptographic key management system with appropriate access controls and auditing.
+* Maintaining a secure crypv6tographic key management system with appropriate access controls and auditing.
 * Regularly evaluating the cryptographic landscape to assess new risks and adapt algorithms accordingly.
 * Discovering and managing cryptographic use cases throughout the application's lifecycle to ensure that all cryptographic assets are accounted for and secured.
 
@@ -193,7 +193,7 @@ Cryptographic hashes are used in a wide variety of cryptographic protocols, such
 | # | Description | L1 | L2 | L3 | CWE |
 | :---: | :--- | :---: | :---: | :---: | :---: |
 | **6.6.1** | [ADDED] Verify that only approved hash functions are used for general cryptographic use cases, including digital signatures, HMAC, KDF, and random bit generation. Approved hash functions are listed below. | | ✓ | ✓ | 916 |
-| **6.6.2** | [ADDED] Verify that slow hashing functions are used for password storage, with appropriate parameter settings as outlined below. | | ✓ | ✓ | 916 |
+| **6.6.2** | [ADDED] Verify that passwords are stored using a slow, computationally intensive hashing algorithm with recommended parameter settings, as outlined below, that balance security and performance to make brute-force attacks more challenging. | | ✓ | ✓ | 916 |
 | **6.6.3** | [ADDED] Verify that cryptographic systems avoid the use of disallowed hash functions, such as MD5, SHA-1, or any other insecure hash functions, for any cryptographic purpose. | ✓ | ✓ | ✓ | 327 |
 | **6.6.4** | [ADDED] Verify that hash functions used in digital signatures are collision resistant and have appropriate bit-lengths to avoid attacks, such as collision or pre-image attacks. | ✓ | ✓ | ✓ | 916 |
 | **6.6.5** | [ADDED] Verify that hash functions used in HMAC, KDF, and random bit generation are derived from those with proper entropy seeding for random bit generation. | | ✓ | ✓ | 916 |
@@ -221,8 +221,8 @@ The following hash functions are specifically recommended for secure password st
 
 | Hash Function | Reference | Required Parameter Sets | L1 | L2 | L3 |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | --|--|--|
-| argon2 | [RFC 9106](https://www.rfc-editor.org/info/rfc9106) | TODO | | ✓ | ✓ |
-| scrypt | [RFC 7914](https://www.rfc-editor.org/info/rfc7914) | TODO | | ✓ | ✓ |
+| argon2 | [RFC 9106](https://www.rfc-editor.org/info/rfc9106) | Argon2ID: Memory Cost 19MB, Time Cost 2, Parallelism 1 | | ✓ | ✓ |
+| scrypt | [RFC 7914](https://www.rfc-editor.org/info/rfc7914) | 2^15 r = 8 p = 1 | | ✓ | ✓ |
 | bcrypt | -- | At least 10 rounds. | | ✓ | ✓ |
 | PBKDF2_SHA512 | [NIST SP 800-132](https://csrc.nist.gov/pubs/sp/800/132/final), [FIPS 180-4](https://csrc.nist.gov/pubs/fips/180-4/upd1/final) | 210,000 iterations | ✓ | ✓ | ✓ |
 | PBKDF2_SHA256 | [NIST SP 800-132](https://csrc.nist.gov/pubs/sp/800/132/final), [FIPS 180-4](https://csrc.nist.gov/pubs/fips/180-4/upd1/final) | 600,000 iterations | ✓ | ✓ | ✓ |


### PR DESCRIPTION
This Pull Request relates to issue #2238

Amended text in 6.6.2 to be more clear

| **6.6.2** | [ADDED] Verify that passwords are stored using a slow, computationally intensive hashing algorithm with recommended parameter settings, as outlined below, that balance security and performance to make brute-force attacks more challenging. | | ✓ | ✓ | 916 |

Added parameters for Argon2ID and scrypt

| argon2 | [RFC 9106](https://www.rfc-editor.org/info/rfc9106) | Argon2ID: Memory Cost 19MB, Time Cost 2, Parallelism 1 | | ✓ | ✓ |
| scrypt | [RFC 7914](https://www.rfc-editor.org/info/rfc7914) | 2^15 r = 8 p = 1 | | ✓ | ✓ |