### PR TITLE
2231: adding concurrency section

### DIFF
--- a/5.0/en/0x18-V10-Coding.md
+++ b/5.0/en/0x18-V10-Coding.md
@@ -78,6 +78,19 @@ Dependency management is critical to the safe operation of any application of an
 | **10.6.1** | [MODIFIED, MOVED FROM 14.2.1] Verify that all components are up to date. | ✓ | ✓ | ✓ | |
 | **10.6.2** | [MODIFIED, MOVED FROM 10.3.2] Verify that third-party components and all of their transitive dependencies are included from the expected repository, whether internally owned or an external source, and that there is no risk of a dependency confusion attack. | ✓ | ✓ | ✓ | 427 |
 
+## V10.7 Concurrency
+
+Without proper synchronization, concurrent access to shared resources can result in corrupted data, system crashes, or unreliable application behavior. Furthermore, race conditions can often be chained to perform privilege escalations or remote code execution.
+
+| # | Description | L1 | L2 | L3 | CWE |
+| :---: | :--- | :---: | :---:| :---: | :---: |
+| **10.7.1** | [MODIFIED, MOVED FROM 1.11.3, LEVEL L2 > L3] Verify that only thread-safe types are used in multi-threaded contexts, or that non-thread-safe types are properly synchronized to prevent race conditions. | | | ✓ | 362 |
+| **10.7.2** | [MODIFIED, MOVED FROM 1.11.2, LEVEL L2 > L3] Verify that concurrent access to shared resources is controlled using synchronization primitives (e.g., locks, mutexes, semaphores) to prevent race conditions and ensure atomic operations on these resources. | | | ✓ | 366 |
+| **10.7.3** | [MODIFIED, MOVED FROM 11.1.6] Verify that all access to shared resources is consistently checked and accessed in a single atomic operation to prevent Time-of-Check to Time-of-Use (TOC/TOU) race conditions, ensuring resource state consistency between check and use. | | ✓ | ✓ | 367 |
+| **10.7.4** | [ADDED] Verify that resource acquisition uses a consistent locking strategy to avoid circular dependencies and ensure forward progress, preventing both deadlocks and livelock scenarios.  | | | ✓ | 833 |
+| **10.7.5** | [ADDED] Verify that resource allocation policies prevent thread starvation by ensuring fair access to resources, such as by leveraging thread pools, allowing lower-priority threads to proceed within a reasonable timeframe. | | | ✓ | 410 |
+| **10.7.6** | [ADDED] Verify that locking primitives are only accessible to the owning class or module and are not publicly modifiable, ensuring that locks cannot be inadvertently or maliciously modified by external classes or code. | | | ✓ | 412 |
+
 ## References
 
 For more information, see also:

--- a/5.0/en/0x19-V11-BusLogic.md
+++ b/5.0/en/0x19-V11-BusLogic.md
@@ -29,8 +29,8 @@ Ensure that a verified application satisfies the following high-level requiremen
 | # | Description | L1 | L2 | L3 | CWE |
 | :---: | :--- | :---: | :---: | :---: | :---: |
 | **1.11.1** | [DELETED, NOT IN SCOPE] | | | | |
-| **1.11.2** | [DELETED, MERGED TO 11.1.6] | | | | |
-| **1.11.3** | [DELETED, MERGED TO 11.1.6] | | | | |
+| **1.11.2** | [MOVED TO 10.7.2] | | | | |
+| **1.11.3** | [DELETED, DUPLICATE OF 11.1.6] | | | | |
 | **1.11.4** | [ADDED] Verify that expectations for business logic limits and validations are clearly documented including both per-user and also globally across the application. | | ✓ | ✓ | |
 
 ## V11.1 Business Logic Security
@@ -44,7 +44,7 @@ Business logic security is so individual to every application that no one checkl
 | **11.1.3** | [MODIFIED, MERGED FROM 11.1.5] Verify that business logic limits and validations are implemented as per the application's documentation. | ✓ | ✓ | ✓ | |
 | **11.1.4** | [MOVED TO 11.2.2] | | | | |
 | **11.1.5** | [DELETED, MERGED TO 11.1.3] | | | | |
-| **11.1.6** | [MODIFIED, MERGED FROM 1.11.2, 1.11.3] Verify that all high-value business logic flows, as well as authentication, session management, and access control, are thread-safe, resistant to time-of-check and time-of-use (TOCTOU) race conditions, and utilize synchronization and locking mechanisms for sensitive operations to maintain internal data consistency and user state. | | ✓ | ✓ | 367 |
+| **11.1.6** | [SPLIT TO 10.7.1, 10.7.2, 10.7.3] | | | | |
 | **11.1.7** | [MOVED TO 7.2.4] | | | | |
 | **11.1.8** | [MOVED TO 7.2.5] | | | | |
 | **11.1.9** | [ADDED] Verify that "atomic transactions" are being used at the business logic level such that either a business logic operation succeeds in its entirety, or it is rolled back to the previous correct state. | | ✓ | ✓ | |


### PR DESCRIPTION
This Pull Request relates to issue [#2231](https://github.com/OWASP/ASVS/issues/2231)

Split the race condition requirement from 11.1.6 into a new, dedicated Concurrency section in V10 to cover:

- Thread-safe types
- Synchronization primitives
- TOC/TOU
- Deadlocks
- Livelocks
- Thread starvation
- Publicly accessible locks

I'm omitting the double-checked locking requirement (which I proposed in the issue) since many frameworks now support a safe implementation of that pattern. It's still discouraged to implement from scratch (using the Java/C# `volatile` keyword for instance) or on certain architectures, but with updates to `volatile` in Java / .NET's lazy initialization, I don't think we should proscribe against it. 