### PR TITLE
6.6.1, remove mention of SHA-1

### DIFF
--- a/5.0/en/0x14-V6-Cryptography.md
+++ b/5.0/en/0x14-V6-Cryptography.md
@@ -96,7 +96,7 @@ Cryptographic hashes are used in a wide variety of cryptographic protocols, such
 
 | # | Description | L1 | L2 | L3 | CWE |
 | :---: | :--- | :---: | :---: | :---: | :---: |
-| **6.6.1** | [ADDED, SPLIT FROM 6.2.5, COVERS 6.2.3] Verify that only approved hash functions are used for general cryptographic use cases, including digital signatures, HMAC, KDF, and random bit generation. Disallowed hash functions, such as MD5, SHA-1, must not be used for any cryptographic purpose. | | ✓ | ✓ | |
+| **6.6.1** | [ADDED, SPLIT FROM 6.2.5, COVERS 6.2.3] Verify that only approved hash functions are used for general cryptographic use cases, including digital signatures, HMAC, KDF, and random bit generation. Disallowed hash functions, such as MD5, must not be used for any cryptographic purpose. | | ✓ | ✓ | |
 | **6.6.2** | [MODIFIED, MOVED FROM 2.4.1, MERGED FROM 2.4.3, 2.4.4, COVERS 2.5.3] Verify that passwords are stored using an approved, computationally intensive, hashing algorithm with parameter settings configured based on current guidance. The settings should balance security and performance to make brute-force attacks more challenging. | | ✓ | ✓ | |
 | **6.6.3** | [ADDED] Verify that hash functions used in digital signatures are collision resistant and have appropriate bit-lengths to avoid attacks, such as collision or pre-image attacks. | ✓ | ✓ | ✓ | |
 


### PR DESCRIPTION
While SHA-1 is not allowed in general, it is still allowed when used in HMAC-SHA-1.