### PR TITLE
Make sed command match on 2-4 digit numbers, not 1 digit numbers

### DIFF
--- a/5.0/Makefile
+++ b/5.0/Makefile
@@ -66,7 +66,12 @@ $(DISTDIR):
 
 # transform origin md files. needed by the next stages
 $(BUILDDIR)/%.md: $(SOURCE_FILES) $(BUILD_FOLDERS) $(BUILDDIR)
-	sed -E 's#(\| ?)([0-9]{1,4})( ?\|)#\1[\2](https://cwe.mitre.org/data/definitions/\2.html)\3#; s#^(\| :?---:? \| :?)---( .*)#\| :-----: \| :---------------------------------------------------\2#; s#.(./images/)#\1#; s#(\\)([rntv])#\\escape{\2}#g' $(patsubst $(BUILDDIR)/%, $(SOURCEDIR)/%, $@) > $@
+	sed -E \
+		-e 's#(\| ?)([0-9]{2,4})( ?\|)#\1[\2](https://cwe.mitre.org/data/definitions/\2.html)\3#' \ # Add links to CWE definitions
+		-e 's#^(\| :?---:? \| :?)---( .*)#\| :-----: \| :---------------------------------------------------\2#' \ # Adjust table formatting
+		-e 's#.(./images/)#\1#' \ # Fix image paths
+		-e 's#(\\)([rntv])#\\escape{\2}#g' \ # Escape special characters
+		$(patsubst $(BUILDDIR)/%, $(SOURCEDIR)/%, $@) > $@
 
 $(DIST_FOLDERS): $(DISTDIR)
 	echo $@

--- a/5.0/Makefile
+++ b/5.0/Makefile
@@ -66,12 +66,7 @@ $(DISTDIR):
 
 # transform origin md files. needed by the next stages
 $(BUILDDIR)/%.md: $(SOURCE_FILES) $(BUILD_FOLDERS) $(BUILDDIR)
-	sed -E \
-		-e 's#(\| ?)([0-9]{2,4})( ?\|)#\1[\2](https://cwe.mitre.org/data/definitions/\2.html)\3#' \ # Add links to CWE definitions
-		-e 's#^(\| :?---:? \| :?)---( .*)#\| :-----: \| :---------------------------------------------------\2#' \ # Adjust table formatting
-		-e 's#.(./images/)#\1#' \ # Fix image paths
-		-e 's#(\\)([rntv])#\\escape{\2}#g' \ # Escape special characters
-		$(patsubst $(BUILDDIR)/%, $(SOURCEDIR)/%, $@) > $@
+	sed -E 's#(\| ?)([0-9]{2,4})( ?\|)#\1[\2](https://cwe.mitre.org/data/definitions/\2.html)\3#; s#^(\| :?---:? \| :?)---( .*)#\| :-----: \| :---------------------------------------------------\2#; s#.(./images/)#\1#; s#(\\)([rntv])#\\escape{\2}#g' $(patsubst $(BUILDDIR)/%, $(SOURCEDIR)/%, $@) > $@
 
 $(DIST_FOLDERS): $(DISTDIR)
 	echo $@

--- a/5.0/tools/export.py
+++ b/5.0/tools/export.py
@@ -33,15 +33,16 @@ from asvs import ASVS
 from cyclonedx import CycloneDX
 
 parser = argparse.ArgumentParser(description='Export the ASVS requirements.')
-parser.add_argument('--format', choices=['json', 'json_flat', 'xml', 'csv', 'cdx_json'], default='json')
+parser.add_argument('--format', choices=['json', 'json_flat', 'xml', 'csv', 'cdx_json', 'raw', 'json_xl', 'v4_mapping', 'v5_mapping'], default='json')
 parser.add_argument('--language', default='en')
-parser.add_argument('--verify-only', default=False)
+parser.add_argument('--verify-only', action='store_true')
+parser.add_argument('--raw-folder', default='')
 
 args = parser.parse_args()
 
 m = ASVS(args.language)
 
-if args.verify_only:
+if bool(args.verify_only):
     if args.format == "csv":
         print(m.verify_csv(m.to_csv()))
     elif args.format == "xml":
@@ -57,6 +58,14 @@ else:
         print(m.to_xml())
     elif args.format == "json_flat":
         print(m.to_json_flat())
+    elif args.format == "json_xl":
+        print(m.to_json_xl())
+    elif args.format == "raw":
+        print(m.to_raw(args.raw_folder))
+    elif args.format == "v4_mapping":
+        print(m.to_v4_mapping())
+    elif args.format == "v5_mapping":
+        print(m.to_v5_mapping())        
     elif args.format == "cdx_json":
         cdx = CycloneDX(m.to_json())
         print(cdx.to_json())


### PR DESCRIPTION
The code is intended to make CWE numbers hyperlinks in the docx and pdf outputs. This might be useful one day for CRE but for now making it not match on single digit numbers should eliminate the current problem that it is adding a hyperlink to the level numbers.