### PR TITLE
Remove out of scope references

### DIFF
--- a/5.0/en/0x10-V1-Architecture.md
+++ b/5.0/en/0x10-V1-Architecture.md
@@ -11,14 +11,3 @@
 | **1.1.5** | [MOVED TO 1.14.7] | | |
 | **1.1.6** | [DELETED, INSUFFICIENT IMPACT] | | |
 | **1.1.7** | [DELETED, NOT IN SCOPE] | | |
-
-## References
-
-For more information, see also:
-
-* [OWASP Threat Modeling Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Threat_Modeling_Cheat_Sheet.html)
-* [OWASP Attack Surface Analysis Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.html)
-* [OWASP Threat modeling](https://owasp.org/www-community/Application_Threat_Modeling)
-* [OWASP Software Assurance Maturity Model Project](https://owasp.org/www-project-samm/)
-* [Microsoft SDL](https://www.microsoft.com/en-us/securityengineering/sdl/)
-* [More information on security.txt including a link to the RFC](https://securitytxt.org/)


### PR DESCRIPTION
Small change to remove references from V1 as they all refer to things that are out of scope for ASVS.