### PR TITLE
Update URL Checker Workflow to Latest Actions

### DIFF
--- a/.github/workflows/url-checker.yml
+++ b/.github/workflows/url-checker.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
 
       - name: Set options
         id: options
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Check URLs
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
         with:
           check-modified-files-only: ${{ steps.options.outputs.check-modified-files-only }}
           config-file: .github/workflows/config/url-checker-config.json


### PR DESCRIPTION
- Updated workflow to use actions/checkout@v4.

- Confirmed `gaurav-nelson/github-action-markdown-link-check@v1.0.15` is the latest stable release.

- No source code changes required; this ensures GitHub Actions run with maintained dependencies.

**Addresses issue #71 by keeping the workflow up-to-date and reducing reliance on deprecated transitive dependencies.**