### PR TITLE
docs: use HTTPS for Creative Commons license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This work is licensed under a
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 
-[cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/
+[cc-by-sa]: https://creativecommons.org/licenses/by-sa/4.0/
 [cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
 [cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-blue.svg
 


### PR DESCRIPTION
This updates the Creative Commons BY-SA 4.0 license reference in README.md to use HTTPS.

No content or meaning changes are introduced.

Fixes #3324