### PR TITLE
Replace deprecated URL checker action with direct invocation

### DIFF
--- a/5.0/en/0x02-Preface.md
+++ b/5.0/en/0x02-Preface.md
@@ -27,6 +27,3 @@ This major revision has been developed with several key principles in mind:
 Just as securing an application is never truly finished, neither is the ASVS. Although Version 5.0 is a major release, development continues. This release allows the wider community to benefit from the improvements and additions which have been accumulated but also lays the groundwork for future enhancements. This could include community-driven efforts to create implementation and verification guidance built on top of the core requirement set.
 
 ASVS 5.0 is designed to serve as a reliable foundation for secure software development. The community is invited to adopt, contribute, and build upon this standard to collectively advance the state of application security.
-
-<!-- TEST: This broken link should be detected by the URL checker and removed before merging -->
-[This link is intentionally broken](https://example.com/this-page-does-not-exist-test-url-checker-12345)


### PR DESCRIPTION
Fixes #3334

## Summary
- The previous `gaurav-nelson/github-action-markdown-link-check@v1` action is [explicitly deprecated](https://github.com/gaurav-nelson/github-action-markdown-link-check)
- Its recommended successor `tcort/github-action-markdown-link-check@v1` has a [known bug](https://github.com/tcort/markdown-link-check/issues/553) where `markdown-link-check` silently fails inside the Docker container, reporting all links as good without actually checking anything
- This PR replaces the Docker-based action with a direct `npm install` and invocation of `markdown-link-check@3.14.2` on the runner, which works correctly
- Also fixes PR-level modified-files detection by using `fetch-depth: 0` (the previous shallow clone approach silently checked zero files)

## Test plan
- [x] Verified broken links are correctly detected (tested via `workflow_dispatch`)
- [x] Verified the workflow runs on `push` and `pull_request` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)