### PR TITLE
Accept 202 link responses and update JWT cheat sheet

### DIFF
--- a/.github/workflows/config/url-checker-config.json
+++ b/.github/workflows/config/url-checker-config.json
@@ -19,7 +19,7 @@
         }
     ],
     "retryOn429": true,
-    "aliveStatusCodes": [200, 403],
+    "aliveStatusCodes": [200, 202, 403],
     "timeout": "30s",
     "fallbackRetryDelay": "30s",
     "see": "https://github.com/tcort/markdown-link-check#config-file-format"

--- a/5.0/en/0x18-V9-Self-contained-Tokens.md
+++ b/5.0/en/0x18-V9-Self-contained-Tokens.md
@@ -33,4 +33,4 @@ Specific requirements for OAuth and OIDC are covered in the dedicated chapter.
 
 For more information, see also:
 
-* [OWASP JSON Web Token Cheat Sheet for Java Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html) (but has useful general guidance)
+* [OWASP JSON Web Token Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_Cheat_Sheet.html)


### PR DESCRIPTION
## Summary
- treat HTTP 202 responses as alive in the markdown link checker
- update the JWT Cheat Sheet reference to the general cheat sheet

## Validation
- parsed the URL checker JSON configuration