### PR TITLE
Support Persian and RTL document generation

### DIFF
--- a/5.0/Makefile
+++ b/5.0/Makefile
@@ -46,6 +46,8 @@ PANDOC_PDF_FLAGS=-f markdown -s -t latex --pdf-engine=xelatex
 
 PANDOC_TEX_FLAGS=-f markdown -s -t latex 
 
+PANDOC_RTL_TABLE_FILTER=--lua-filter=$(TOOLSDIR)/rtl_tables.lua
+
 PANDOC_DOCX_FLAGS= -s \
 				  -t docx \
 				  -f markdown \
@@ -90,11 +92,11 @@ md: $(MD_FILES)
 	echo $(MD_FILES)
 
 $(PDF_FILES): $(BUILD_FOLDERS) $(TARGETS) $(DIST_FOLDERS) transform-md
-	pandoc $(PANDOC_PDF_FLAGS) --include-in-header=$(TEMPLATEDIR)/header-eisvogel.tex -o $@ --template $(TEMPLATEDIR)/eisvogel.tex $(subst dist,build,$(@D)/*.md) $(subst dist,,$(@D)/0x00-Header.yaml)
+	pandoc $(PANDOC_PDF_FLAGS) $(PANDOC_RTL_TABLE_FILTER) --include-in-header=$(TEMPLATEDIR)/header-eisvogel.tex -o $@ --template $(TEMPLATEDIR)/eisvogel.tex $(subst dist,build,$(@D)/*.md) $(subst dist,,$(@D)/0x00-Header.yaml)
 pdf: $(PDF_FILES)
 
 $(TEX_FILES): $(BUILD_FOLDERS) $(TARGETS) $(DIST_FOLDERS)
-	pandoc $(PANDOC_TEX_FLAGS) --include-in-header=$(TEMPLATEDIR)/header-eisvogel.tex -o $@ --template $(TEMPLATEDIR)/eisvogel.tex $(subst dist,build,$(@D)/*.md) $(subst dist,,$(@D)/0x00-Header.yaml)
+	pandoc $(PANDOC_TEX_FLAGS) $(PANDOC_RTL_TABLE_FILTER) --include-in-header=$(TEMPLATEDIR)/header-eisvogel.tex -o $@ --template $(TEMPLATEDIR)/eisvogel.tex $(subst dist,build,$(@D)/*.md) $(subst dist,,$(@D)/0x00-Header.yaml)
 tex: $(TEX_FILES)
 
 $(DOCX_FILES): $(BUILD_FOLDERS) $(TARGETS) $(DIST_FOLDERS)

--- a/5.0/templates/eisvogel.tex
+++ b/5.0/templates/eisvogel.tex
@@ -205,6 +205,7 @@ $endif$
 $if(zero-width-non-joiner)$
 %% Support for zero-width non-joiner characters.
 \makeatletter
+\providecommand{\textormath}[1]{#1}
 \def\zerowidthnonjoiner{%
   % Prevent ligatures and adjust kerning, but still support hyphenating.
   \texorpdfstring{%

--- a/5.0/tools/rtl_tables.lua
+++ b/5.0/tools/rtl_tables.lua
@@ -1,0 +1,22 @@
+-- Pandoc preserves Markdown's default left table alignment in LaTeX output,
+-- even when the document direction is RTL. Convert those columns to right
+-- alignment for RTL documents while preserving explicit centered columns.
+
+local function align_table_right(table)
+  for index, colspec in ipairs(table.colspecs) do
+    local alignment = colspec[1]
+    if alignment == pandoc.AlignDefault or alignment == pandoc.AlignLeft then
+      table.colspecs[index] = { pandoc.AlignRight, colspec[2] }
+    end
+  end
+
+  return table
+end
+
+function Pandoc(document)
+  if pandoc.utils.stringify(document.meta.dir) ~= "rtl" then
+    return document
+  end
+
+  return document:walk({ Table = align_table_right })
+end

--- a/5.0/tools/rtl_tables.lua
+++ b/5.0/tools/rtl_tables.lua
@@ -14,7 +14,8 @@ local function align_table_right(table)
 end
 
 function Pandoc(document)
-  if pandoc.utils.stringify(document.meta.dir) ~= "rtl" then
+  local direction = document.meta.dir
+  if direction == nil or pandoc.utils.stringify(direction) ~= "rtl" then
     return document
   end
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,6 +56,11 @@ RUN for font in source-sans source-serif source-code-pro; do \
     done
 RUN mkdir adobe-fonts
 RUN find $PWD/ -name "*.ttf" -exec install -m644 {} adobe-fonts/ \; || return 1
+RUN curl -L --retry 5 \
+    "https://github.com/aliftype/amiri/releases/download/1.003/Amiri-1.003.zip" \
+    --output amiri.zip \
+    && unzip amiri.zip \
+    && find $PWD/ -path "*/Amiri-1.003/*.ttf" -exec install -m644 {} adobe-fonts/ \;
 RUN rm -rf $PWD/source*
 
 FROM base_${WITH_CERT} as pandoc_base


### PR DESCRIPTION
## Summary

- install the bilingual Amiri font in the document builder
- provide the LaTeX fallback needed for Persian zero-width non-joiners
- right-align default/left table columns in RTL PDF and TeX output
- leave LTR documents unchanged when direction metadata is absent

## Scope

This PR contains only reusable document-generation changes extracted from #3370. It excludes Persian translation content, generated outputs, and changes to 5.0/languages.txt.

## Validation

- git diff --check passes
- the RTL filter was used to generate and visually inspect Persian requirement-table pages
- the filter includes a guard for LTR documents without dir metadata