### PR TITLE
[v5.0.0] Bump dorny/paths-filter from 3.0.2 to 4.0.2 (#3378) | Bump actions/upload-artifact from 4.3.0 to 7.0.1 (#3379) | Bump tj-actions/changed-files from 46 to 47 (#3380) | Bump actions/download-artifact from 4.3.0 to 8.0.1 (#3381) | Bump actions/checkout from 4 to 7 (#3382)

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -14,7 +14,7 @@ jobs:
       packages: write
     name: Build and publish
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
 
       - name: 'Login to GitHub Container Registry'
         uses: docker/login-action@v3.4.0

--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.2.2
-    - uses: dorny/paths-filter@v3.0.2
+    - uses: dorny/paths-filter@v4.0.2
       id: filter
       with:
         filters: |

--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -15,7 +15,7 @@ jobs:
   filters:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
     - uses: dorny/paths-filter@v4.0.2
       id: filter
       with:

--- a/.github/workflows/create-4.0-outputs.yml
+++ b/.github/workflows/create-4.0-outputs.yml
@@ -19,7 +19,7 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
       - uses: actions/checkout@v4.2.2
       - run: make 4.0
-      - uses: actions/upload-artifact@v4.4.3
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: ASVS 4.0.3
           path: 4.0/docs_*

--- a/.github/workflows/create-4.0-outputs.yml
+++ b/.github/workflows/create-4.0-outputs.yml
@@ -17,7 +17,7 @@ jobs:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
       - run: make 4.0
       - uses: actions/upload-artifact@v7.0.1
         with:

--- a/.github/workflows/create-5.0-outputs.yml
+++ b/.github/workflows/create-5.0-outputs.yml
@@ -34,7 +34,7 @@ jobs:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v7
       - run: make 5.0
         env:
           LANGS: ${{ inputs.languages || github.event.inputs.languages || 'en' }}

--- a/.github/workflows/create-5.0-outputs.yml
+++ b/.github/workflows/create-5.0-outputs.yml
@@ -38,7 +38,7 @@ jobs:
       - run: make 5.0
         env:
           LANGS: ${{ inputs.languages || github.event.inputs.languages || 'en' }}
-      - uses: actions/upload-artifact@v4.3.0
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: ASVS 5.0.0
           path: 5.0/dist/

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - name: markdownlint-cli

--- a/.github/workflows/publish-5.0-latest.yml
+++ b/.github/workflows/publish-5.0-latest.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
       - name: Download 5.0 artifact
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ASVS 5.0.0
           path: ./asvs-5.0-latest

--- a/.github/workflows/publish-5.0-latest.yml
+++ b/.github/workflows/publish-5.0-latest.yml
@@ -10,7 +10,7 @@ jobs:
     name: Publish 5.0 Latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
       - name: Download 5.0 artifact
         uses: actions/download-artifact@v8.0.1
         with:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get changed files (PR only)
         if: github.event_name == 'pull_request'
         id: files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             5.0/en/**/*.md

--- a/.github/workflows/url-checker.yml
+++ b/.github/workflows/url-checker.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/validate_translation.yml
+++ b/.github/workflows/validate_translation.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v5.0.0`:
 - [Bump dorny/paths-filter from 3.0.2 to 4.0.2 (#3378)](https://github.com/OWASP/ASVS/pull/3378)
 - [Bump actions/upload-artifact from 4.3.0 to 7.0.1 (#3379)](https://github.com/OWASP/ASVS/pull/3379)
 - [Bump tj-actions/changed-files from 46 to 47 (#3380)](https://github.com/OWASP/ASVS/pull/3380)
 - [Bump actions/download-artifact from 4.3.0 to 8.0.1 (#3381)](https://github.com/OWASP/ASVS/pull/3381)
 - [Bump actions/checkout from 4 to 7 (#3382)](https://github.com/OWASP/ASVS/pull/3382)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)